### PR TITLE
updated DocumentExtraction docs to include ondocument and standard presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ pip3 install indico-client
 
 From source:
 ```bash
-git clone https://github.com/IndicoDataSolutions/indicoio-py.git
+git clone https://github.com/IndicoDataSolutions/indico-client-python.git
 python3 setup.py install
 ```
 

--- a/docsrc/docextract_settings.rst
+++ b/docsrc/docextract_settings.rst
@@ -28,7 +28,7 @@ by passing in a Python dictionary or JSON string.
 Here's an Example::
 
     my_ocr_config = {
-        "preset_config": "simple"
+        "preset_config": "standard"
     }
 
     job = client.call(DocumentExtraction(files=['./path_to_doc.pdf'], json_config=my_ocr_config))
@@ -45,14 +45,21 @@ Setting::
     "preset_config": "simple"
     "preset_config": "legacy"
     "preset_config": "detailed"
+    "preset_config": "ondocument"
+    "preset_config": "standard"
 
-Three preset ocr configurations are provided: ``legacy``, ``simple`` and ``detailed``. Most users will
-only need to use "simple". "legacy" is intended for users who ran Indico's original pdf_extraction
-function to extract text and train models. Use "legacy" if you are adding samples to models that were trained with
-the original pdf_extraction. "detailed" provides OCR metrics and details down to the character level- it's a lot of data.
+Three preset ocr configurations are provided: ``legacy``, ``simple``, ``ondocument``, ``standard``, 
+and ``detailed``. Most users will only need to use "standard" to get text and block positions in 
+a nested response format. "simple" provides a basic and fast (3-5x faster) OCR option for native PDFs 
+(it will not work with scanned documents). "legacy" is intended for users who ran Indico's 
+original pdf_extraction function to extract text and train models. Use "legacy" if you are 
+adding samples to models that were trained with the original pdf_extraction. "detailed" provides 
+OCR metrics and details down to the character level- it's a lot of data. "ondocument" provides 
+similar information to "detailed" but at the page rather than document-level, in an unnested format, 
+and without document metadata. 
 
-The exact settings included in "legacy", "simple" and "detailed" are shown at the bottom
-of this page.
+The exact settings included in "legacy", "simple", "ondocument", "standard", and "detailed" 
+are shown at the bottom of this page.
 
 Result Granularity
 ------------------
@@ -396,4 +403,25 @@ Settings included in presets::
         "tokens": {"text", "page_num", "position", "style", "doc_offset", "confidence"},
         "chars": {"text", "position", "confidence", "doc_index", "alternate_ocr"},
         "batch_size": 1,
+    }
+
+    standard = {
+        "nest": True,
+        "top_level": "document",
+        "native_pdf": False,
+        "document": {"text"},
+        "pages": {"text", "doc_offset", "page_num"},
+        "blocks": {"text", "position", "doc_offset", "page_offset"},
+        "batch_size": 1,
+    }
+
+    ondocument = {
+        "top_level": "page",
+        "nest": False,
+        "reblocking": {"style", "lists", "inline-header"},
+        "pages": {"text", "size", "dpi", "doc_offset", "page_num", "image", "thumbnail"},
+        "blocks": {"text", "doc_offset", "page_offset", "position", "block_type", "page_num"},
+        "tokens": {"text", "doc_offset", "page_offset", "block_offset", "position", "page_num", "style"},
+        "chars": {"text", "doc_index", "block_index", "page_index", "page_num", "position"},
+        "batch_size": 1
     }

--- a/docsrc/docextract_settings.rst
+++ b/docsrc/docextract_settings.rst
@@ -48,7 +48,7 @@ Setting::
     "preset_config": "ondocument"
     "preset_config": "standard"
 
-Three preset ocr configurations are provided: ``legacy``, ``simple``, ``ondocument``, ``standard``, 
+Five preset ocr configurations are provided: ``legacy``, ``simple``, ``ondocument``, ``standard``, 
 and ``detailed``. Most users will only need to use "standard" to get text and block positions in 
 a nested response format. "simple" provides a basic and fast (3-5x faster) OCR option for native PDFs 
 (it will not work with scanned documents). "legacy" is intended for users who ran Indico's 

--- a/indico/queries/documents.py
+++ b/indico/queries/documents.py
@@ -38,7 +38,7 @@ class _DocumentExtraction(GraphQLRequest):
         }
     """
 
-    def __init__(self, files, json_config={"preset_config": "simple"}):
+    def __init__(self, files, json_config={"preset_config": "legacy"}):
         if json_config and type(json_config) == dict:
             json_config = json.dumps(json_config)
         super().__init__(
@@ -70,13 +70,17 @@ class DocumentExtraction(RequestChain):
     Raises:
 
     Notes:
-        DocumentExtraction is extremely configurable. Three preset configurations are provided:
+        DocumentExtraction is extremely configurable. Four preset configurations are provided:
 
-        simple - Most applications won't need more than this.
+        simple - Provides a simple and fast response for native PDFs (3-5x faster). Will NOT work with scanned PDFs.
 
-        legacy - Provided to mimic the behavior of Indico's older pdf_extraction function. Use this if your model was trained with data from pdf_extraction.
+        legacy - Provided to mimic the behavior of Indico's older pdf_extraction function. Use this if your model was trained with data from the older pdf_extraction.
         
-        detailed - Provides detailed bounding box information on tokens and characters.
+        detailed - Provides detailed bounding box information on tokens and characters. Returns data in a nested format at the document level with all metadata included.
+
+        ondocument - Provides detailed information at the page-level in an unnested format.
+
+        standard - Provides page text and block text/position in a nested format.
 
         For more information, please see the DocumentExtraction settings page.
 
@@ -84,11 +88,9 @@ class DocumentExtraction(RequestChain):
 
         Call DocumentExtraction and wait for the result::
 
-            job = client.call(DocumentExtraction(files=[src_path], json_config='{"preset_config": "simple"}'))
+            job = client.call(DocumentExtraction(files=[src_path], json_config='{"preset_config": "legacy"}'))
             job = client.call(JobStatus(id=job[0].id, wait=True))
-            if job is not None and job.status == 'SUCCESS':
-                json_data = client.call(RetrieveStorageObject(job.result))
-                print(json.dumps(json_data, indent=4))
+            extracted_data = client.call(RetrieveStorageObject(job.result))
     """
 
     def __init__(self, files: List[str], json_config: dict = None):


### PR DESCRIPTION
Updated the DocumentExtraction docs and docstring to include "ondocument" and (pending) "standard" preset configurations. For now, changed default preset to "legacy" (should change to "standard" when it's ready) and clarified that "simple" is only for native PDFs. Fixed git clone readme snippet to clone this repo.