### PR TITLE
Updated DocumentExtraction documentation for preset configurations

### DIFF
--- a/docsrc/docextract_settings.rst
+++ b/docsrc/docextract_settings.rst
@@ -80,11 +80,11 @@ Result Granularity
 
 Setting::
 
-    "top_level": "page" (default)
-    "top_level": "document"
+    "top_level": "page" 
+    "top_level": "document" (default) 
 
 The "document" kwarg will return a nested dictionary with text data at both the page and document level 
-(i.e. unified document text *and* text data at the page-level). The "page" kwarg will return 
+(i.e. text data at the page-level *and* the full document text). The "page" kwarg will return 
 a list of dictionaries where each dictionary is page-level text data and no document-level data is included.
 
 Nesting

--- a/docsrc/docextract_settings.rst
+++ b/docsrc/docextract_settings.rst
@@ -12,14 +12,16 @@ by the ``DocumentExtraction`` class. Here's how to OCR one document with Documen
     from indico.queries.documents import DocumentExtraction
     from indico.queries import JobStatus, RetrieveStorageObject
 
-    # assumes you have your api token in your working or home directory
+    # here, IndicoClient assumes you have your api token in your home directory and host set as an env variable
     client = IndicoClient()
     files_to_extract = client.call(DocumentExtraction(files=['./path_to_document.pdf']))
     extracted_file = client.call(JobStatus(id=files_to_extract[0].id, wait=True))
-    json_result = client.call(RetrieveStorageObject(extracted_file.result))
+    result = client.call(RetrieveStorageObject(extracted_file.result))
 
 In this example, given the path to a document, we called DocumentExtraction with a single file and waited for the result.
-With most use cases, this is all you will need to do.
+With most use cases, this is all you will need to do. The returned 'result' will either be a dictionary (if 
+document-level text and/or metadata are requested) or a list of dictionaries (where each dictionary contains 
+the text for a unique page/block).
 
 ``DocumentExtraction`` is highly configurable. You can customize settings at the document, page, block, token or
 character level. You can also choose from a selection of preset configurations. You configure DocumentExtraction
@@ -49,14 +51,26 @@ Setting::
     "preset_config": "standard"
 
 Five preset ocr configurations are provided: ``legacy``, ``simple``, ``ondocument``, ``standard``,
-and ``detailed``. Most users will only need to use "standard" to get text and block positions in
-a nested response format. "simple" provides a basic and fast (3-5x faster) OCR option for native PDFs
-(it will not work with scanned documents). "legacy" is intended for users who ran Indico's
-original pdf_extraction function to extract text and train models. Use "legacy" if you are
-adding samples to models that were trained with the original pdf_extraction. "detailed" provides
-OCR metrics and details down to the character level- it's a lot of data. "ondocument" provides
-similar information to "detailed" but at the page rather than document-level, in an unnested format,
-and without document metadata.
+and ``detailed``. 
+
+Most users will only need to use "standard" to get both document and page-level text and block positions in
+a nested response format (returned object is a nested dictionary). 
+
+The "simple" configuration provides a basic and fast (3-5x faster) OCR option for native PDFs- i.e. it will 
+*not* work with scanned documents. Returns document, page, and block-level text and the returned object is a
+nested dictionary. 
+
+The "legacy" configuration is principally intended for users who ran Indico's original pdf_extraction function to extract
+text and train models. Use "legacy" if you are adding samples to models that were trained with data using 
+the original pdf_extraction. It returns a dictionary containing only the extracted text at the document-level. 
+
+The "detailed" configuration provides OCR metrics and details down to the character level- it's a lot of data.
+In addition to document, page, and block-level text, it provides information on the text font/size, 
+confidence level for extracted characters, alternative characters (i.e. second most probable character), character 
+position information, and more. It returns a nested dictionary.   
+
+"ondocument" provides similar information to "detailed" but does not include text/metadata at the 
+document-level. It returns a list of dictionaries where each dictionary is page data. 
 
 The exact settings included in "legacy", "simple", "ondocument", "standard", and "detailed"
 are shown at the bottom of this page.
@@ -69,18 +83,20 @@ Setting::
     "top_level": "page" (default)
     "top_level": "document"
 
-The JSON result can be a single result for the entire document ("document") or
-broken into a list with one item for each page ("page").
+The "document" kwarg will return a nested dictionary with text data at both the page and document level 
+(i.e. unified document text *and* text data at the page-level). The "page" kwarg will return 
+a list of dictionaries where each dictionary is page-level text data and no document-level data is included.
 
 Nesting
 -------
 
 Setting::
 
-    "nest": True
+    "nest": True (default)
     "nest": False
 
-Set to ``True`` to nest the JSON result. (i.e. {“pages”: [{“blocks”:) or flat? (i.e. {“pages”: [], “blocks”: [],)
+Set to ``True`` to nest the dictionary results or ``False`` to unnest them. 
+(i.e. nested- {“pages”: [{“blocks”:}]} *or*  unnested- {“pages”: [], “blocks”: [],})
 
 Parse Order
 -----------
@@ -145,7 +161,7 @@ Setting::
     "text": True
     "text": False
 
-Set to ``True`` to include whole document-level text in the JSON result. Document-level text will always include tables
+Set to ``True`` to include whole document-level text in the result. Document-level text will always include tables
 as they appear on the page.
 
 


### PR DESCRIPTION
Added more information on what the preset configurations do and what python objects they return, removed a reference to the api token being recognized (without an explicit path) in the working directory, added some additional details/context for a couple of kwargs.