### PR TITLE
catching most common object retrieval error 

### DIFF
--- a/indico/queries/storage.py
+++ b/indico/queries/storage.py
@@ -20,6 +20,9 @@ class RetrieveStorageObject(HTTPRequest):
 
     def __init__(self, storage_object):
         if type(storage_object) == dict:
+            if "url" not in storage_object.keys():
+                raise KeyError("Unable to retrieve result. Please check the job status error for more details\
+                                and ensure that you are using the correct credentials and specifications for your use case")
             url = storage_object["url"]
         else:
             url = storage_object

--- a/indico/queries/storage.py
+++ b/indico/queries/storage.py
@@ -1,6 +1,7 @@
 import json
 from typing import List
 from indico.client.request import HTTPMethod, HTTPRequest
+from indico.errors import IndicoRequestError
 
 
 class RetrieveStorageObject(HTTPRequest):
@@ -20,10 +21,14 @@ class RetrieveStorageObject(HTTPRequest):
 
     def __init__(self, storage_object):
         if type(storage_object) == dict:
-            if "url" not in storage_object.keys():
-                raise KeyError("Unable to retrieve result. Please check the job status error for more details\
-                                and ensure that you are using the correct credentials and specifications for your use case")
-            url = storage_object["url"]
+            try:
+                url = storage_object["url"]
+            except KeyError:
+                raise IndicoRequestError(
+                    code="FAILURE",
+                    error="Unable to retrieve result. Please check the job status error for more details\
+                    and ensure that you are using the correct credentials and specifications for your use case",
+                )
         else:
             url = storage_object
 

--- a/indico/queries/storage.py
+++ b/indico/queries/storage.py
@@ -26,8 +26,8 @@ class RetrieveStorageObject(HTTPRequest):
             except KeyError:
                 raise IndicoRequestError(
                     code="FAILURE",
-                    error="Unable to retrieve result. Please check the job status error for more details\
-                    and ensure that you are using the correct credentials and specifications for your use case",
+                    error="Unable to retrieve result. Please check the status of the job object. If the status is \
+                    'FAILURE', check the job object result for more detailed information.",
                 )
         else:
             url = storage_object


### PR DESCRIPTION
When a user doesn't check if a Job.status is 'FAILURE' they are most likely going to run into a KeyError 'url'  when calling RetrieveStorageObject (most often when doing OCR w/ DocumentExtraction). Our Chatham clients (as well as myself and Andrew) have all run into this error and been initially stuck as to what the problem might be.

Updated with two lines to check if 'url' is in the storage object dictionary and, if not, raise an error for the user to check the job result/status and suggest that it could be a credential/specification issue. Even though this could be avoided in a user's own code, it has been a common problem already and seems that, for now, an easy fix with a better error message might save clients some frustration. 