### PR TITLE
Improving error message when an invalid model group is called

### DIFF
--- a/indico/queries/model_groups.py
+++ b/indico/queries/model_groups.py
@@ -42,9 +42,12 @@ class GetModelGroup(GraphQLRequest):
         super().__init__(query=self.query, variables={"id": id})
 
     def process_response(self, response):
-        mg = ModelGroup(
-            **super().process_response(response)["modelGroups"]["modelGroups"][0]
-        )
+        try:
+            mg = ModelGroup(
+                **super().process_response(response)["modelGroups"]["modelGroups"][0]
+            )
+        except IndexError:
+            IndicoNotFound('ModelGroup not found. Please check the ID you are using.')
         return mg
 
 


### PR DESCRIPTION
If you currently use an invalid modelgroup ID with this call:

`model_id = client.call(GetModelGroup(25147))`

You get:

```
~/Desktop/jupyter_kernels/new_client/venv/lib/python3.7/site-packages/indico/queries/model_groups.py in process_response(self, response)
     44     def process_response(self, response):
     45         mg = ModelGroup(
---> 46             **super().process_response(response)["modelGroups"]["modelGroups"][0]
     47         )
     48         return mg

IndexError: list index out of range
```
Improving this error to let the user know that the ModelGroup hasn't been found and to check the ID they're using. 