### PR TITLE
Fixing errors/issues with the README code examples

### DIFF
--- a/indico/queries/storage.py
+++ b/indico/queries/storage.py
@@ -20,6 +20,9 @@ class RetrieveStorageObject(HTTPRequest):
 
     def __init__(self, storage_object):
         if type(storage_object) == dict:
+            if "url" not in storage_object.keys():
+                raise KeyError("Unable to retrieve result. Please check the job status error for more details\
+                                and ensure that you are using the correct credentials and specifications for your use case")
             url = storage_object["url"]
         else:
             url = storage_object

--- a/indico/queries/storage.py
+++ b/indico/queries/storage.py
@@ -1,6 +1,7 @@
 import json
 from typing import List
 from indico.client.request import HTTPMethod, HTTPRequest
+from indico.errors import IndicoRequestError
 
 
 class RetrieveStorageObject(HTTPRequest):
@@ -20,10 +21,14 @@ class RetrieveStorageObject(HTTPRequest):
 
     def __init__(self, storage_object):
         if type(storage_object) == dict:
-            if "url" not in storage_object.keys():
-                raise KeyError("Unable to retrieve result. Please check the job status error for more details\
-                                and ensure that you are using the correct credentials and specifications for your use case")
-            url = storage_object["url"]
+            try:
+                url = storage_object["url"]
+            except KeyError:
+                raise IndicoRequestError(
+                    code="FAILURE",
+                    error="Unable to retrieve result. Please check the job status error for more details\
+                    and ensure that you are using the correct credentials and specifications for your use case",
+                )
         else:
             url = storage_object
 

--- a/indico/queries/storage.py
+++ b/indico/queries/storage.py
@@ -26,8 +26,8 @@ class RetrieveStorageObject(HTTPRequest):
             except KeyError:
                 raise IndicoRequestError(
                     code="FAILURE",
-                    error="Unable to retrieve result. Please check the job status error for more details\
-                    and ensure that you are using the correct credentials and specifications for your use case",
+                    error="Unable to retrieve result. Please check the status of the job object. If the status is \
+                    'FAILURE', check the job object result for more detailed information.",
                 )
         else:
             url = storage_object


### PR DESCRIPTION
Fixing the following issues/errors in the README (only listing a few here, but most follow same pattern): 

- Code doesnt look for the token in the working directory, removing that wording

- Several problems with the import errors in the first code example, incl: ListModelGroups (incorrect location), import 'indico' but never use it, no module named indico.queries.job, etc. etc. 

- Not sure what JobResult is, but can't be imported from the location listed and documentation samples use JobStatus (which is imported from the wrong location in the example)

- code includes job.result(), but result is attribute not method)

Tested both new examples and they work as expected