### PR TITLE
FIX:dont require exact python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,7 @@ setup(
     url="https://github.com/IndicoDataSolutions/indico-client-python",
     author="indico",
     author_email="engineering@indico.io",
-    tests_require=[
-        "pytest>=5.2.1",
-        "requests-mock>=1.7.0-7"
-    ],
+    tests_require=["pytest>=5.2.1", "requests-mock>=1.7.0-7"],
     install_requires=[
         "msgpack==1.0.0",
         "msgpack-numpy==0.4.4.3",
@@ -24,7 +21,7 @@ setup(
         "Pillow>=6.2.0",
         "requests>=2.22.0",
         "setuptools>=41.4.0",
-        "pandas==0.23.4",
+        "pandas>=0.23.4",
         'importlib-metadata ~= 1.0 ; python_version < "3.8"',
     ],
 )


### PR DESCRIPTION
Pinning python version may be annoying for people on python 1.0 locally. We only brought in python to be able to read a dataframe.