### PR TITLE
suppress warnings when verify_ssl=False in config

### DIFF
--- a/indico/client/client.py
+++ b/indico/client/client.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 
 from typing import Union
+import urllib3
 
 from indico.config import IndicoConfig
 from indico.http.client import HTTPClient
 from indico.client.request import HTTPRequest, RequestChain
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class IndicoClient:

--- a/indico/client/client.py
+++ b/indico/client/client.py
@@ -7,8 +7,6 @@ from indico.config import IndicoConfig
 from indico.http.client import HTTPClient
 from indico.client.request import HTTPRequest, RequestChain
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-
 
 class IndicoClient:
     """
@@ -29,6 +27,8 @@ class IndicoClient:
     def __init__(self, config: IndicoConfig = None):
         if not config:
             config = IndicoConfig()
+        if not config.verify_ssl:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.config = config
         self._http = HTTPClient(config)
 


### PR DESCRIPTION
Currently, many of our clients need to set verify_ssl=False in the their configuration (WR Berkley for example) like:

```
config = IndicoConfig(verify_ssl=False)
client = IndicoClient(config)
```

This leads to hundreds of warnings (depending on how the script is written) in the terminal like below that drown out all other print statements and look bad to the client: 
```
  InsecureRequestWarning,
/home/scott/Desktop/wrberk/venv/lib/python3.7/site-packages/urllib3/connectionpool.py:988: InsecureRequestWarning: Unverified HTTPS request is being made to host 'wrb-pilot.indico.domains'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
```
This PR suppresses those warnings