### PR TITLE
added ability to pass session params from config

### DIFF
--- a/indico/config/config.py
+++ b/indico/config/config.py
@@ -15,6 +15,7 @@ class IndicoConfig:
         api_token_path= (str, optional): Path to the Indico API token file indico_api_token.txt
         api_token= (str, optional): The actual text of the API Token
         verify_ssl= (bool, optional): Verify the host's SSL certificate? Default=True
+        requests_params= (dict, optional): Dictionary of requests.Session parameters to set
 
     Returns:
         IndicoConfig object
@@ -29,7 +30,10 @@ class IndicoConfig:
         indico_api_token.txt file in the user's home directory.
 
         If your Indico Platform host is configured to use http instead of https or if the
-        host has an invalid SSL certificate then be sure to set verify_ssl=True
+        host has an invalid SSL certificate then be sure to set verify_ssl=False
+
+        The requests_params dictionary should have keys that are valid attributes of the Session
+        object from the requests library. 
     """
 
     host: str
@@ -38,6 +42,7 @@ class IndicoConfig:
     api_token_path: str
     api_token: str = None
     verify_ssl: bool = True
+    requests_params: dict = None
     _disable_cookie_domain: bool = False
 
     def __init__(self, **kwargs):

--- a/indico/http/client.py
+++ b/indico/http/client.py
@@ -35,6 +35,9 @@ class HTTPClient:
         self.base_url = f"{self.config.protocol}://{self.config.host}"
 
         self.request_session = requests.Session()
+        if config and isinstance(config.requests_params, dict):
+            for param in config.requests_params.keys():
+                setattr(self.request_session, param, config.requests_params[param])
         self.request_session.cookies.set_policy(CookiePolicyOverride())
         self.get_short_lived_access_token()
 
@@ -89,7 +92,7 @@ class HTTPClient:
                 files.append(fd)
                 # follow the convention of adding (n) after a duplicate filename
                 if path.stem in dup_counts:
-                    file_arg[path.stem+f"({dup_counts[path.stem]})"] = fd
+                    file_arg[path.stem + f"({dup_counts[path.stem]})"] = fd
                     dup_counts[path.stem] += 1
                 else:
                     file_arg[path.stem] = fd

--- a/tests/unit/client/test_client.py
+++ b/tests/unit/client/test_client.py
@@ -4,18 +4,26 @@ import pytest
 from indico.client import IndicoClient, HTTPRequest, HTTPMethod, GraphQLRequest
 from indico.config import IndicoConfig
 
+
 @pytest.fixture(scope="function")
 def indico_request(requests_mock):
     def new_request_mock(method, path, *args, **kwargs):
         config = IndicoConfig()
         url = f"{config.protocol}://{config.host}" + path
-        getattr(requests_mock, method)(url, *args, **kwargs, headers={"Content-Type": "application/json"})
+        getattr(requests_mock, method)(
+            url, *args, **kwargs, headers={"Content-Type": "application/json"}
+        )
+
     return new_request_mock
 
 
 @pytest.fixture(scope="function")
 def auth(indico_request):
-    indico_request("post", "/auth/users/refresh_token", json={"auth_token": "asdfsdfasdfasdfasdfasdf"})
+    indico_request(
+        "post",
+        "/auth/users/refresh_token",
+        json={"auth_token": "asdfsdfasdfasdfasdfasdf"},
+    )
 
 
 def test_client_basic_http_request(indico_request, auth):
@@ -25,24 +33,69 @@ def test_client_basic_http_request(indico_request, auth):
     response = client.call(HTTPRequest(method=HTTPMethod.GET, path="/users/details"))
     assert response == {"test": True}
 
+
 def test_client_graphql_text_request(indico_request, auth):
     client = IndicoClient()
     indico_request("post", "/graph/api/graphql", json={"data": {"datasets": []}})
 
-    response = client.call(GraphQLRequest(query="query list_datasets($ids: List(Int)) { datasets(ids: $ids) { id } }", variables={"ids": [1,2,3,4]}))
+    response = client.call(
+        GraphQLRequest(
+            query="query list_datasets($ids: List(Int)) { datasets(ids: $ids) { id } }",
+            variables={"ids": [1, 2, 3, 4]},
+        )
+    )
     assert response == {"datasets": []}
 
 
 def test_client_verify_true_request(indico_request, auth):
     client = IndicoClient()
-    indico_request("post", "/graph/api/graphql", additional_matcher=lambda r: r.verify, json={"data": {"datasets": []}})
+    indico_request(
+        "post",
+        "/graph/api/graphql",
+        additional_matcher=lambda r: r.verify,
+        json={"data": {"datasets": []}},
+    )
 
-    response = client.call(GraphQLRequest(query="query list_datasets($ids: List(Int)) { datasets(ids: $ids) { id } }", variables={"ids": [1,2,3,4]}))
+    response = client.call(
+        GraphQLRequest(
+            query="query list_datasets($ids: List(Int)) { datasets(ids: $ids) { id } }",
+            variables={"ids": [1, 2, 3, 4]},
+        )
+    )
     assert response == {"datasets": []}
+
 
 def test_client_verify_false_request(indico_request, auth):
     client = IndicoClient(IndicoConfig(verify_ssl=False))
-    indico_request("post", "/graph/api/graphql", additional_matcher=lambda r: not r.verify, json={"data": {"datasets": []}})
+    indico_request(
+        "post",
+        "/graph/api/graphql",
+        additional_matcher=lambda r: not r.verify,
+        json={"data": {"datasets": []}},
+    )
 
-    response = client.call(GraphQLRequest(query="query list_datasets($ids: List(Int)) { datasets(ids: $ids) { id } }", variables={"ids": [1,2,3,4]}))
+    response = client.call(
+        GraphQLRequest(
+            query="query list_datasets($ids: List(Int)) { datasets(ids: $ids) { id } }",
+            variables={"ids": [1, 2, 3, 4]},
+        )
+    )
+    assert response == {"datasets": []}
+
+
+def test_client_requests_params(indico_request, auth):
+    client = IndicoClient(IndicoConfig(requests_params={"verify": False}))
+    indico_request(
+        "post",
+        "/graph/api/graphql",
+        additional_matcher=lambda r: not r.verify,
+        json={"data": {"datasets": []}},
+    )
+
+    response = client.call(
+        GraphQLRequest(
+            query="query list_datasets($ids: List(Int)) { datasets(ids: $ids) { id } }",
+            variables={"ids": [1, 2, 3, 4]},
+        )
+    )
     assert response == {"datasets": []}


### PR DESCRIPTION
Added ability to pass dictionary of requests.Sessions parameters to set 

Note: the only real change to tests/unit/client/test_client.py is the last test, all the other changes are just from applying black formatting. 