### PR TITLE
[DEV-5292]: FIX request chain, existing test, and add test

### DIFF
--- a/indico/queries/datasets.py
+++ b/indico/queries/datasets.py
@@ -239,11 +239,13 @@ class CreateDataset(RequestChain):
             yield _ProcessCSV(dataset_id=dataset_id, datafile_ids=csv_files)
         elif non_csv_files:
             yield _ProcessFiles(dataset_id=dataset_id, datafile_ids=non_csv_files)
-        yield GetDatasetStatus(id=dataset_id)
+        yield GetDatasetFileStatus(id=dataset_id)
         debouncer = Debouncer()
         if self.wait is True:
-            while self.previous not in ["COMPLETE", "FAILED"]:
-                yield GetDatasetStatus(id=dataset_id)
+            while not all(
+                [f.status in ["PROCESSED", "FAILED"] for f in self.previous.files]
+            ):
+                yield GetDatasetFileStatus(id=dataset_id)
                 debouncer.backoff()
         yield GetDataset(id=dataset_id)
 

--- a/tests/integration/data/classification.csv
+++ b/tests/integration/data/classification.csv
@@ -1,0 +1,24477 @@
+row_index,user_id,text,single_1,single_2,single_3,multi_1,multi_2,multi_3,annotation
+0,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+1,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+2,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+3,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+4,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+5,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+6,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+7,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+8,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+9,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+10,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+11,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+12,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+13,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+14,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+15,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+16,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+17,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+18,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+19,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+20,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+21,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+22,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+23,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+24,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+25,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+26,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+27,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+28,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+29,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+30,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+31,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+32,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+33,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+34,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+35,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+36,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+37,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+38,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+39,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+40,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+41,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+42,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+43,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+44,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+45,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+46,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+47,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+48,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+49,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+50,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+51,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+52,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+53,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+54,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+55,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+56,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+57,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+58,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+59,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+60,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+61,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+62,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+63,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+64,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+65,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+66,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+67,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+68,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+69,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+70,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+71,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+72,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+73,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+74,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+75,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+76,13929,"Invoice
+
+#Z93SE5Q-U3A0JH
+
+We received payment for your Zeplin subscription. Thank you!
+Learn how to update invoice and billing information. For any other
+questions, ping us anytime at support@zeplin.io.
+
+Date Oct 26, 2018
+
+Subscribed with engineer@indico.io
+
+Charged to MasterCard (**** **** ****)
+
+For service through
+
+Oct 26, 2019
+
+Subscription to Growing Business $312.00
+
+Subtotal $312.00
+
+Total
+
+$312.00
+
+Paid $312.00
+
+Thank you!
+
+Zeplin, Inc
+350 Brannan St., Suite 350
+San Francisco, CA 94107
+United States
+
+EIN: 35 - 2533442","""tools""","""zeplin-asana-amazon""",,"[""tools""]",,,"[{""label"":""invoice"",""start"":9,""end"":24},{""label"":""vendor"",""start"":436,""end"":447}]"
+94,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+95,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+96,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+97,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+98,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+99,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+100,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+101,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+102,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+103,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+104,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+105,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+106,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+107,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+108,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+109,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+110,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+111,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+112,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+113,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+114,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+115,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+116,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+117,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+118,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+119,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+120,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+121,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+122,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+123,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+124,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+125,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+126,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+127,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+128,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+129,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+130,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+131,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+132,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+133,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+134,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+135,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+136,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+137,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+138,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+139,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+140,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+141,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+142,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+143,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+144,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+145,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+146,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+147,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+148,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+149,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+150,13929,"HubSpot, Inc.
+2 First Street,
+
+Boston, MA 02141 Tax
+ID: 11-2665791
+
+indico data solutions, INC
+Bill To: Ship To:
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+186 SOUTH STREET
+SUITE 400
+Boston MA 02111
+US
+
+Item Billing Frequency
+
+HubSpot Enterprise Monthly
+Included Contacts Monthly
+Enterprise Contacts - Per 1000 Monthly
+
+Credit Card Receipt 579266
+Date                        06/21/2016
+Portal ID                   3927578
+Currency                    USD
+
+Start Date  End Date    Quantity  Line Total
+06/21/2016  07/20/2016  1         $1,200.00
+06/21/2016  07/20/2016  10        $0.00
+06/21/2016  07/20/2016  5         $25.00
+
+Subtotal   $1,225.00
+Total Tax  $76.56
+Total      $1,301.56
+
+Please contact your Account Manager for any questions related to your contract. For any other general invoicing inquiries, please send
+an email to bills@hubspot.net
+
+1 / 1","""business""",,,"[""business"", ""organization""]",,,"[{""label"":""vendor"",""start"":0,""end"":13},{""label"":""invoice"",""start"":345,""end"":351}]"
+154,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+155,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+156,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+157,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+158,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+159,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+160,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+161,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+162,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+163,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+164,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+165,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+166,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+167,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+168,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+169,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+170,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+171,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+172,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+173,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+174,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+175,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+176,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+177,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+178,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+179,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+180,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+181,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+182,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+183,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+184,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+185,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+186,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+187,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+188,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+189,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+190,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+191,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+192,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+193,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+194,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+195,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+196,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+197,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+198,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+199,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+200,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+201,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+202,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+203,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+204,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+205,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+206,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+207,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+208,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+209,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+210,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+211,13929,"Venture Advisors
+
+14 North Road
+Sudbury, MA 01776
+(781) 273-6074
+ktempo@venture-
+advisors.com
+
+INVOICE
+
+BILL TO
+
+Indico
+186 South Street
+Suite 400
+Boston, MA 02111
+
+INVOICE # 3860
+DATE 04/30/2017
+
+DUE DATE
+
+04/30/2017
+
+TERMS
+
+Due on receipt
+
+DATE ACTIVITY QTY RATE AMOUNT
+
+04/30/2017
+
+Services
+
+Finance services
+
+4.75 175.00 831.25
+
+Tax I.D. 27-1577081
+ACH payments:
+
+Citizens Bank
+ABA/Trans routing # 288202936
+Bank Acct. # 13126789876
+PLEASE NOTE OUR NEW ADDRESS ABOVE
+
+BALANCE DUE
+
+$831.25","""business""",,,"[""business""]",,,"[{""label"":""vendor"",""start"":0,""end"":16},{""label"":""invoice"",""start"":175,""end"":179}]"
+216,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+217,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+218,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+219,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+220,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+221,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+222,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+223,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+224,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+225,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+226,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+227,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+228,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+229,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+230,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+231,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+232,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+233,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+234,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+235,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+236,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+237,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+238,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+239,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+240,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+241,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+242,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+243,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+244,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+245,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+246,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+247,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+248,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+249,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+250,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+251,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+252,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+253,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+254,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+255,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+256,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+257,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+258,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+259,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+260,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+261,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+262,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+263,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+264,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+265,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+266,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+267,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+268,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+269,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+270,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+271,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+272,13929,"Invoice
+
+Sold -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Bill -To
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+Service Usage Address
+
+Default Directory
+186 South Street Suite 400
+Boston MA 02111
+United States
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Order Details                                 Billing Summary
+Product:             Online Services          Charges:         66.00
+Customer PO Number:                           Discounts:       0.00
+Order Number:        b011d605-7137-4dd8-abdd  Credits:         0.00
+Billing Period:      03/14/2020 - 04/13/2020  Tax:             4.13
+Payment Terms:       Net 30                   Total:           70.13
+Due Date:            05/14/2020
+
+Payment Instructions
+
+Please DO NOT PAY. You will be charged the amount due through your selected method of payment.
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+Page 1 of 2
+Invoice
+
+April 2020
+Invoice Date: 04/14/2020
+Invoice Number: E0600AT
+Due Date: 05/14/2020
+
+70.13 USD
+
+Office 365 Business
+Service Period           Days  Qty  Monthly Price  Charges  Discounts  Credits  SubTotal  Tax %   Tax   Total
+04/13/2020 - 05/12/2020  30    8    8.25           66.00    0.00       0.00     66.00     6.25 %  4.13  70.13
+SubTotal                                           66.00    0.00       0.00     66.00             4.13  70.13
+
+Grand Total
+
+66.00
+
+0.00
+
+0.00
+
+66.00
+
+Billing or service question? Call 1-800-865-9408 or visit https://aka.ms/Office365Billing.
+
+Microsoft Corporation, One Microsoft Way Redmond, WA 98052 United States
+US FEIN 91-1144442
+
+4.13
+
+70.13
+
+Page 2 of 2","""tools""","""computers""","""microsoft""","[""tools"", ""technology"", ""computers"", ""office""]","[""technology"", ""microsoft""]","[""office""]","[{""label"":""invoice"",""start"":332,""end"":339},{""label"":""invoice"",""start"":1184,""end"":1193},{""label"":""vendor"",""start"":1020,""end"":1041},{""label"":""vendor"",""start"":1709,""end"":1731}]"
+302,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+303,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+304,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+305,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+306,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+307,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+308,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+309,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+310,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+311,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+312,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+313,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+314,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+315,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+316,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+317,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+318,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+319,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+320,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+321,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+322,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+323,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+324,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+325,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+326,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+327,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+328,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+329,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+330,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+331,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+332,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+333,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+334,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+335,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+336,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+337,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+338,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+339,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+340,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+341,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+342,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+343,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+344,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+345,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+346,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+347,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+348,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+349,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+350,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+351,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+352,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+353,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+354,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+355,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+356,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+357,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+358,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+359,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+360,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+361,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+362,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+363,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+364,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+365,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+366,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+367,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+368,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+369,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+370,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+371,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+372,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+373,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+374,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+375,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+376,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+377,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+378,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+379,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+380,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+381,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+382,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+383,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+384,13929,"Account number:
+
+348723987438
+
+Bill to Address:
+
+129 South Street
+Boston , MA , 02111 , US
+
+Amazon Web Services Invoice
+
+Email or talk to us about your AWS account or bill, visit aws.amazon.com/contact-us/
+
+Invoice Summary
+
+Invoice Number: 34782384
+Invoice Date: October 3 , 2015
+
+TOTAL AMOUNT DUE ON October 3 , 2015 $782.31
+
+This invoice is for the billing period September 1 - September 30 , 2015
+
+Greetings from Amazon Web Services, we're writing to provide you with an electronic invoice for your use of AWS services. Additional information
+regarding your bill, individual service charge details, and your account history are available on the Account Activity Page.
+
+Summary
+AWS Service Charges     $782.31
+Charges                 $29,518.98
+Credits                 ($28,736.67)
+Tax *                   $0.00
+Total for this invoice  $782.31
+
+Detail
+Amazon Simple Storage Service           $0.00
+Charges                                 $137.94
+Credits                                 ($137.94)
+Estimated US sales tax to be collected  $0.00
+AWS Data Transfer                       $0.00
+Charges                                 $866.15
+Credits                                 ($866.15)
+Estimated US sales tax to be collected  $0.00
+Amazon SimpleDB                         $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+AWS Support (Business)                  $782.31
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+1
+Charges                                 $2,211.52
+Credits                                 ($1,429.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic MapReduce                $0.00
+Charges                                 $566.21
+Credits                                 ($566.21)
+Estimated US sales tax to be collected  $0.00
+Amazon Elastic Compute Cloud            $0.00
+Charges                                 $25,735.92
+Credits                                 ($25,735.92)
+Estimated US sales tax to be collected  $0.00
+AWS Key Management Service              $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Queue Service             $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+Amazon Route 53                         $0.00
+Charges                                 $1.24
+Credits                                 ($1.24)
+Estimated US sales tax to be collected  $0.00
+Amazon Simple Notification Service      $0.00
+Charges                                 $0.00
+Estimated US sales tax to be collected  $0.00
+
+* May include estimated US sales tax, VAT, GST and CT.
+Amazon Web Services, Inc. foreign registration number is 00004
+AWS, Inc. is a ""Registered Foreign Supplier"" under Japanese Consumption Tax Law and therefore AWS,
+Inc. is required to declare and pay consumption tax in respect of this transaction (as a “Digital Service”)
+to the Japan Tax Authority.
+** This is not a VAT invoice
+*** Check the GST statement attached at the end of this Invoice for details
+† Usage and recurring charges for this statement period will be charged on your next billing date. The
+amount of your actual charges for this statement period may differ from the charges shown on this
+page. The charges shown on this page do not include any additional usage charges accrued during this
+statement period after the date you are viewing this page. Also, one-time fees and subscription charges
+are assessed separately, on the date that they occur.
+All charges and prices are in US Dollars
+All AWS Services are sold by Amazon Web Services, Inc.
+
+Service Provider:
+
+(Not to be used for payment remittance)
+Amazon Web Services, Inc.
+410 Terry Ave North
+Seattle , WA 98109-5210 , US
+
+2","""cloud""","""zeplin-asana-amazon""",,"[""cloud"", ""technology""]","[""technology""]","[""cloud""]","[{""label"":""vendor"",""start"":92,""end"":111},{""label"":""invoice"",""start"":246,""end"":255}]"
+434,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+435,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+436,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+437,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+438,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+439,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+440,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+441,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+442,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+443,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+444,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+445,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+446,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+447,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+448,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+449,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+450,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+451,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+452,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+453,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+454,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+455,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+456,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+457,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+458,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+459,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+460,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+461,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+462,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+463,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+464,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+465,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+466,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+467,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+468,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+469,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+470,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+471,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+472,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+473,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+474,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+475,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+476,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+477,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+478,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+479,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+480,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+481,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+482,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+483,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+484,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+485,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+486,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+487,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+488,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+489,13929,"Asana
+
+Invoice
+
+10 Bryant Street
+San Francisco, CA 94103
+United States
+Email: service@asana.com
+
+Bill To
+indico.io
+186 SOUTH STREET
+400
+Boston, MA 02111-2833
+United States
+
+Invoice # 819823
+Billed On Oct 9, 2018
+Terms On -Receipt
+Due On Oct 9, 2018
+
+PAID
+
+on Oct 9, 2018
+
+$1,125.00 USD
+
+Date Description Qty Price Subtotal
+
+Oct 9, 2018 – Oct 9, 2019 Organization Annual 1 $1,125.00 $1,125.00
+
+Payments
+Oct 9, 2018 $1,125.00 Payment from MasterCard ···
+
+Notes
+
+All amounts in United States Dollars (USD)
+
+Subtotal $1,125.00
+
+Total $1,125.00
+
+Paid ($1,125.00)
+
+Amount Due $0.00
+
+Page 1 of 1","""tools""","""zeplin-asana-amazon""",,"[""tools"", ""organization"", ""office""]","[""asana-google""]","[""office""]","[{""label"":""vendor"",""start"":0,""end"":5},{""label"":""invoice"",""start"":183,""end"":189}]"
+528,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+529,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+530,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+531,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+532,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+533,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+534,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+535,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+536,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+537,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+538,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+539,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+540,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+541,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+542,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+543,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+544,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+545,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+546,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+547,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+548,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+549,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+550,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+551,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"
+552,13929,"Invoice
+
+Invoice number: 326985
+
+Bill to
+Indico Data Solutions
+186 South Street Suite 400
+Boston, MA 02111
+United States
+
+Details
+
+.....Invoice. ... ......number.... ....  .....3526648......... .
+..Invoice...... .....date ....           ..Nov ....30, ...2018
+....Billing......ID. ....                5048
+.....Domain........name.... ....         .....indicoio.....
+
+You will be automatically charged for any amount due.
+
+Google LLC
+1600 Amphitheatre Pkwy
+Mountain View, CA 94043
+United States
+Federal Tax ID: 77-0493581
+
+Google Cloud - GSuite
+Total in USD                            $155.83
+Summary for Nov 1, 2018 - Nov 30, 2018
+Subtotal in USD                         $146.66
+State sales tax (6.25%)                 $9.17
+Total in USD                            $155.83
+
+Page 1 of 2
+Invoice Invoice number: 3526694835
+
+Subscription Description Interval Quantity Amount($)
+
+G Suite Business Commitment Nov 1 - Nov 30 22 146.66
+
+Subtotal in USD $146.66
+State sales tax (6.25%) $9.17
+
+Total in USD $155.83
+
+Page 2 of 2","""cloud""","""computers""","""google""","[""cloud"", ""technology"", ""computers""]","[""technology"", ""asana-google""]","[""google"", ""cloud""]","[{""label"":""invoice"",""start"":25,""end"":32},{""label"":""vendor"",""start"":249,""end"":259}]"

--- a/tests/integration/queries/test_dataset.py
+++ b/tests/integration/queries/test_dataset.py
@@ -392,3 +392,16 @@ def test_csv_incompat_columns(indico):
 
     assert dataset.status == "COMPLETE"
 
+
+def test_bad_csv_create_dataset(indico):
+    client = IndicoClient()
+    dataset_filepath = str(Path(__file__).parents[1]) + "/data/classification.csv"
+    dataset = client.call(
+        CreateDataset(
+            name=f"dataset-{int(time.time())}", files=[dataset_filepath], wait=True
+        ),
+    )
+
+    assert dataset.status == "CREATING"
+    dataset = client.call(GetDatasetFileStatus(id=dataset.id))
+    assert all([f.status == "FAILED" for f in dataset.files])

--- a/tests/integration/queries/test_dataset.py
+++ b/tests/integration/queries/test_dataset.py
@@ -375,7 +375,7 @@ def test_csv_incompat_columns(indico):
     datafile_ids = [
         df.id
         for df in dataset.files
-        if df.status == "DOWNLOADED" and df.file_type == "csv"
+        if df.status == "DOWNLOADED" and df.file_type == "CSV"
     ]
 
     dataset = client.call(


### PR DESCRIPTION
After the `test_csv_incompat_columns` test was written, I had fixed fog to use the correct enum type so that file_type is returned as `CSV` instead of `csv` at which point this test was out of date.  The reason it hangs is because we call `ProcessCSV` with wait and the file never gets processed because we passed in an empty list of `datafile_ids`. So we keep polling for dataset file statuses and they never leave `DOWNLOADED` state. 

Separately, the logic for `CreateDataset` request chain wait was incorrect. It should wait on file statuses not on dataset status because we may not fail a dataset if there is failure processing a file. When a user attempts to process a datafile that is associated with a dataset it should end up in either PROCESSED or FAILED state. 

No platform bugs in both cases.