### PR TITLE
FIX: require some args to be keyword-only

### DIFF
--- a/indico/queries/submission.py
+++ b/indico/queries/submission.py
@@ -13,15 +13,15 @@ from indico.types.submission import VALID_SUBMISSION_STATUSES
 
 class ListSubmissions(GraphQLRequest):
     """
-    List all Submissions visible to the authenticated user by most recent. 
+    List all Submissions visible to the authenticated user by most recent.
 
-    Args:
-        submission_ids (List[int], optional): Submission ids to filter by
-        workflow_ids (List[int], optional): Workflow ids to filter by
-        filters (SubmissionFilter or Dict, optional): Submission attributes to filter by
-        limit (int, optional): Maximum number of Submissions to return. Defaults to 1000
-        orderBy (str, optional): Order by field. Defaults to id
-        desc: (bool, optional): Order direction. Defaults to descending order to get most recent submissions
+    Options:
+        submission_ids (List[int]): Submission ids to filter by
+        workflow_ids (List[int]): Workflow ids to filter by
+        filters (SubmissionFilter or Dict): Submission attributes to filter by
+        limit (int, default=1000): Maximum number of Submissions to return
+        orderBy (str, default="ID"): Submission attribute to filter by
+        desc: (bool, default=True): List in descending order
     Returns:
         List[Submission]: All the found Submission objects
     """
@@ -60,12 +60,13 @@ class ListSubmissions(GraphQLRequest):
 
     def __init__(
         self,
+        *,
         submission_ids: List[int] = None,
         workflow_ids: List[int] = None,
         filters: Union[Dict, SubmissionFilter] = None,
         limit: int = 1000,
         order_by: str = "ID",
-        desc: bool = True
+        desc: bool = True,
     ):
         super().__init__(
             self.query,
@@ -75,7 +76,7 @@ class ListSubmissions(GraphQLRequest):
                 "filters": filters,
                 "limit": limit,
                 "orderBy": order_by,
-                "desc": desc
+                "desc": desc,
             },
         )
 

--- a/indico/queries/workflow.py
+++ b/indico/queries/workflow.py
@@ -10,11 +10,9 @@ class ListWorkflows(GraphQLRequest):
     """
     List all workflows visible to authenticated user
 
-    Args:
-        dataset_ids (List[int], optional): List of dataset ids to filter by.
-            Defaults to None
-        workflow_ids (List[int], optional): List of workflow ids to filter by
-            Defaults to None
+    Options:
+        dataset_ids (List[int]): List of dataset ids to filter by
+        workflow_ids (List[int]): List of workflow ids to filter by
 
     Returns:
         List[Workflow]: All the found Workflow objects
@@ -32,7 +30,9 @@ class ListWorkflows(GraphQLRequest):
         }
     """
 
-    def __init__(self, dataset_ids: List[int] = None, workflow_ids: List[int] = None):
+    def __init__(
+        self, *, dataset_ids: List[int] = None, workflow_ids: List[int] = None
+    ):
         super().__init__(
             self.query,
             variables={"datasetIds": dataset_ids, "workflowIds": workflow_ids},
@@ -135,7 +135,6 @@ class _WorkflowUrlSubmission(_WorkflowSubmission):
     mutation_name = "workflowUrlSubmission"
 
 
-
 class WorkflowSubmission(RequestChain):
     """
     Submit files to a workflow for processing.
@@ -155,6 +154,7 @@ class WorkflowSubmission(RequestChain):
             Otherwise, they will be AsyncJob ids.
 
     """
+
     detailed_response = False
 
     def __init__(
@@ -206,6 +206,7 @@ class WorkflowSubmissionDetailed(WorkflowSubmission):
         List[Submission]: Submission objects created
 
     """
+
     detailed_response = True
 
     def __init__(


### PR DESCRIPTION
Basically don't allow folks to pass in args where we'd prefer kwargs (to prevent any unexpected results)
![image](https://user-images.githubusercontent.com/10765889/96935396-f4836f80-1491-11eb-91d0-21e6655cbb47.png)

Also something worth adding is an "Options" part to the docstring to distinguish between required args and optional ones. could change that up in this PR - or we can decide on some standard and I can clean it all up in a separate PR