### PR TITLE
catch index error from bad id

### DIFF
--- a/indico/queries/model_groups/metrics.py
+++ b/indico/queries/model_groups/metrics.py
@@ -98,11 +98,20 @@ class ObjectDetectionMetrics(GraphQLRequest):
         super().__init__(self.query, variables={"modelGroupId": model_group_id})
 
     def process_response(self, response):
-        return json.loads(
-            super().process_response(response)["modelGroups"]["modelGroups"][0][
-                "selectedModel"
-            ]["evaluation"]["metrics"]
-        )
+        try:
+            return json.loads(
+                super().process_response(response)["modelGroups"]["modelGroups"][0][
+                    "selectedModel"
+                ]["evaluation"]["metrics"]
+            )
+        except IndexError:
+            raise IndicoRequestError(
+                (
+                    "No results found. Please check that you have used the correct Model Group ID "
+                    "(*not* the selected model ID) and have permission to access that model."
+                ),
+                code=400,
+            )
 
 
 task_type_query_mapping = {

--- a/tests/integration/queries/test_model_group.py
+++ b/tests/integration/queries/test_model_group.py
@@ -226,7 +226,7 @@ def test_object_detection_metrics_bad_id(indico):
     from indico import IndicoConfig
     client = IndicoClient()
     with pytest.raises(IndicoRequestError):
-        _ = client.call(ObjectDetectionMetrics(-1))
+        client.call(ObjectDetectionMetrics(-1))
 
 
 def test_model_group_metrics_query(

--- a/tests/integration/queries/test_model_group.py
+++ b/tests/integration/queries/test_model_group.py
@@ -30,7 +30,7 @@ from ..data.datasets import (
     org_annotate_model_group,
     org_annotate_dataset,
 )
-from indico.errors import IndicoNotFound
+from indico.errors import IndicoNotFound, IndicoRequestError
 
 
 def test_create_model_group(airlines_dataset: Dataset):
@@ -220,6 +220,13 @@ def test_object_detection_metrics(
     result = client.call(ObjectDetectionMetrics(cats_dogs_modelgroup.id))
     for metric_type in ["AP", "AP-Cat", "AP-Dog\n", "AP50", "AP75"]:
         assert isinstance(result["bbox"][metric_type], float)
+
+
+def test_object_detection_metrics_bad_id(indico):
+    from indico import IndicoConfig
+    client = IndicoClient()
+    with pytest.raises(IndicoRequestError):
+        _ = client.call(ObjectDetectionMetrics(-1))
 
 
 def test_model_group_metrics_query(


### PR DESCRIPTION
Currently if you pass an invalid model group ID to ObjectDetectionMetrics, you get an IndexError (result returns empty from grapqhl query). Catching that error and raising a helpful exception message. 