### PR TITLE
fix 3.9 issue

### DIFF
--- a/indico/types/base.py
+++ b/indico/types/base.py
@@ -3,8 +3,7 @@ import json
 from typing import List, Any
 from indico.types.utils import cc_to_snake
 
-generic_alias_cls = type(List)
-
+generic_alias_cls = type(List[Any])
 
 def list_subtype(cls):
     if not issubclass(type(cls), generic_alias_cls):

--- a/tox.Dockerfile
+++ b/tox.Dockerfile
@@ -6,7 +6,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yqq apt-tr
 #deadsnakes holds old versions of python for ubuntu
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -yqq software-properties-common && add-apt-repository ppa:deadsnakes/ppa
 
-RUN  DEBIAN_FRONTEND=noninteractive apt-get -yqq install  python3.7 python3.8 python3-pip
+RUN  DEBIAN_FRONTEND=noninteractive apt-get -yqq install  python3.7 python3.8 python3.9 python3-pip
 
 RUN pip3 install tox==3.22.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py37,py38
+envlist = py37,py38,py39
 
 [testenv]
 parallel_show_output = true


### PR DESCRIPTION
some changes in 3.9 mean the way list types were previously detected no longer work, but this should fix the issue and work with older versions as well