### PR TITLE
[CAT-102] byte stream support

### DIFF
--- a/indico/queries/storage.py
+++ b/indico/queries/storage.py
@@ -1,5 +1,6 @@
+import io
 import json
-from typing import List
+from typing import List, Dict
 from indico.client.request import HTTPMethod, HTTPRequest, RequestChain
 from indico.errors import IndicoRequestError, IndicoInputError
 
@@ -46,14 +47,20 @@ class UploadDocument(HTTPRequest):
     Used internally for uploading documents to indico platform for later processing
 
     Args:
-        filepaths (str): list of filepaths to upload
+        files (str): A list of local filepaths to upload.
+        streams (Dict[str, io.BufferedIOBase]): A dict of filenames to BufferedIOBase streams
+            (any class that inherits BufferedIOBase is acceptable).
 
     Returns:
         files: storage objects to be use for further processing requests E.G. Document extraction (implicitly called)
     """
 
-    def __init__(self, files: List[str]):
-        super().__init__(HTTPMethod.POST, "/storage/files/store", files=files)
+    def __init__(self, files: List[str] = None, streams: Dict[str, io.BufferedIOBase] = None):
+
+        if (files is None and streams is None) or (files is not None and streams is not None):
+            raise IndicoInputError("Must define one of files or streams, but not both.")
+
+        super().__init__(HTTPMethod.POST, "/storage/files/store", files=files, streams=streams)
 
     def process_response(self, uploaded_files: List[dict]):
         files = [
@@ -124,5 +131,5 @@ class CreateStorageURLs(UploadDocument):
         return urls
 
 
-# Alias to ensure backwards compatability
+# Alias to ensure backwards compatibility
 UploadImages = CreateStorageURLs


### PR DESCRIPTION
## Summary

This enables SDK users to manage their own file reading and upload to the backend by providing a map of filenames to  streams, so in addition to`files` on a `WorkflowSubmission`, you can add `io.BufferedIOBase` inheriting `streams` directly.

## Changelog (optional)
Modified WorkflowSubmission object to add optional streams
Modified Storage upload object to add optional streams
Modified client.py to handle the optional streams similar to files.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:
A quick checklist of things that should be done before the code is opened to review by others on the team.
Delete any that are not applicable.

- [x] Jira story/task is put into PR title
- [x] Code has been self-reviewed
- [x] Hard-to-understand areas have been commented
- [ ] Documentation has been updated
- [x] My changes generate no new warnings
- [x] Unit tests have been added for base functionality and known edge cases
