### PR TITLE
[CAT-171] & [CAT-168] Fix exception handling for hibernation and decoding

### DIFF
--- a/indico/errors.py
+++ b/indico/errors.py
@@ -42,5 +42,6 @@ class IndicoAuthenticationFailed(IndicoError):
 
 class IndicoHibernationError(IndicoError):
     def __init__(self, after):
+        self.after = after
         super().__init__(f"Platform is currently hibernating. Wait {after} seconds and retry this request.")
 

--- a/indico/errors.py
+++ b/indico/errors.py
@@ -38,3 +38,9 @@ class IndicoNotFound(IndicoError):
 class IndicoAuthenticationFailed(IndicoError):
     def __init__(self):
         super().__init__("Failed to authenticate")
+
+
+class IndicoHibernationError(IndicoError):
+    def __init__(self, after):
+        super().__init__(f"Platform is currently hibernating. Wait {after} seconds and retry this request.")
+

--- a/indico/http/client.py
+++ b/indico/http/client.py
@@ -164,7 +164,7 @@ class HTTPClient:
         elif response.status_code == 401 and _refreshed:
             raise IndicoAuthenticationFailed()
 
-        if response.status_code == 502 and 'Retry-After' in response.headers:
+        if response.status_code == 503 and 'Retry-After' in response.headers:
             raise IndicoHibernationError(after=response.headers.get('Retry-After'))
 
         if response.status_code >= 500:

--- a/indico/http/client.py
+++ b/indico/http/client.py
@@ -9,7 +9,7 @@ from typing import Union
 import requests
 from indico.client.request import HTTPRequest
 from indico.config import IndicoConfig
-from indico.errors import IndicoAuthenticationFailed, IndicoRequestError
+from indico.errors import IndicoAuthenticationFailed, IndicoRequestError, IndicoHibernationError
 from indico.http.serialization import deserialize
 from requests import Response
 
@@ -155,8 +155,6 @@ class HTTPClient:
         if len(url_parts) > 1 and (url_parts[-1] == "json" or url_parts[-2] == "json"):
             json = True
 
-        content = deserialize(response, force_json=json)
-
         # If auth expired refresh
         if response.status_code == 401 and not _refreshed:
             self.get_short_lived_access_token()
@@ -166,6 +164,15 @@ class HTTPClient:
         elif response.status_code == 401 and _refreshed:
             raise IndicoAuthenticationFailed()
 
+        if response.status_code == 502 and 'Retry-After' in response.headers:
+            raise IndicoHibernationError(after=response.headers.get('Retry-After'))
+
+        if response.status_code >= 500:
+            raise IndicoRequestError(
+                code=response.status_code
+            )
+
+        content = deserialize(response, force_json=json)
         if response.status_code >= 400:
             if isinstance(content, dict):
                 error = (

--- a/indico/http/client.py
+++ b/indico/http/client.py
@@ -173,6 +173,7 @@ class HTTPClient:
             )
 
         content = deserialize(response, force_json=json)
+
         if response.status_code >= 400:
             if isinstance(content, dict):
                 error = (


### PR DESCRIPTION
## Summary

Moved the error handling for 500 errors above the attempt to decode content so that an` IndicoDecodingError` doesn't get thrown before the server errors are checked.

Added a check for a 503 response code and throw an `IndicoHibernationError` if the retry-after header is set.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Jira story/task is put into PR title
- [x] Code has been self-reviewed
- [x] My changes generate no new warnings
