### PR TITLE
Added error messaging for Dataset basetype methods

### DIFF
--- a/indico/types/dataset.py
+++ b/indico/types/dataset.py
@@ -3,6 +3,7 @@ from typing import List
 
 from indico.types.base import BaseType
 from indico.types.datafile import Datafile
+from indico.errors import IndicoInputError
 
 
 class DataColumn(BaseType):
@@ -55,10 +56,14 @@ class Dataset(BaseType):
     datacolumns: List[DataColumn]
 
     def labelset_by_name(self, name: str) -> LabelSet:
-        return next(l for l in self.labelsets if l.name == name)
+        if name not in [lab.name for lab in self.labelsets]:
+            raise IndicoInputError(f"No labelset found for {name}. Current labelset names include {[lab.name for lab in self.labelsets]}.")
+        return next(lab for lab in self.labelsets if lab.name == name)
 
     def datacolumn_by_name(self, name: str) -> DataColumn:
-        return next(l for l in self.datacolumns if l.name == name)
+        if name not in [datacol.name for datacol in self.datacolumns]:
+            raise IndicoInputError(f"No datacolumn found for {name}. Current datacolumn names include {[datacol.name for datacol in self.datacolumns]}.")
+        return next(datacol for datacol in self.datacolumns if datacol.name == name)
 
 
 class TableReadOrder(Enum):


### PR DESCRIPTION
## Summary
Looking to improve error handling for `Dataset` base type. Raises an `IndicoInputError` vs a `StopIteration` error when name is not found for methods `labelset_by_name` and `datacolumn_by_name`. 

## Changelog 
- Added conditions to `Dataset` methods to check if name is present. If not, raise `IndicoInputError`. 
- If labelset or datacolumn not found, listing available names for user. 

## Type of change
- [ ] Error handling (adding more detail to errors???)

## Checklist:
- [ ] Code has been self-reviewed
- [ ] My changes generate no new warnings
