### PR TITLE
[CAT-232] FIX: Update Document Report Filter behavior

### DIFF
--- a/indico/filters/__init__.py
+++ b/indico/filters/__init__.py
@@ -166,22 +166,24 @@ class DocumentReportFilter(Filter):
     ):
 
         kwargs = {"workflowId": workflow_id, "id": submission_id, "status": status}
-        if created_at_start_date is not None and created_at_end_date is not None:
+        if created_at_end_date and not created_at_start_date:
+            raise IndicoInputError("Must specify created_at_start_date")
+        if created_at_start_date:
             kwargs["createdAt"] = {
-                "from": created_at_start_date.strftime("%Y-%m-%d")
-                if created_at_start_date is not None
-                else "",
+                "from": created_at_start_date.strftime("%Y-%m-%d"),
                 "to": created_at_end_date.strftime("%Y-%m-%d")
                 if created_at_end_date is not None
-                else "",
+                else datetime.datetime.now().strftime("%Y-%m-%d"),
             }
-        if updated_at_start_date is not None and updated_at_end_date is not None:
+
+
+        if updated_at_end_date and not updated_at_start_date:
+            raise IndicoInputError("Must specify updated_at_start_date")
+        if updated_at_start_date is not None:
             kwargs["updatedAt"] = {
-                "from": updated_at_start_date.strftime("%Y-%m-%d")
-                if updated_at_start_date is not None
-                else "",
+                "from": updated_at_start_date.strftime("%Y-%m-%d"),
                 "to": updated_at_end_date.strftime("%Y-%m-%d")
                 if updated_at_end_date is not None
-                else "",
+                else datetime.datetime.now().strftime("%Y-%m-%d"),
             }
         super().__init__(**kwargs)

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -1,7 +1,8 @@
 import pytest
+from datetime import datetime
 
 from indico.errors import IndicoInputError
-from indico.filters import Filter, SubmissionFilter, and_, or_
+from indico.filters import Filter, SubmissionFilter, and_, or_, DocumentReportFilter
 
 
 def test_filter():
@@ -24,3 +25,17 @@ def test_builder(fn, key):
 def test_submission_filter():
     f = SubmissionFilter(status="complete")
     assert dict(f) == {"status": "COMPLETE"}
+
+
+def test_doc_report_filter():
+    todays_date = datetime.now().strftime("%Y-%m-%d")
+
+    filter_opts = DocumentReportFilter(created_at_start_date=datetime(2021, 7, 1))
+    assert filter_opts['createdAt']['to'] == todays_date
+    with pytest.raises(IndicoInputError):
+        DocumentReportFilter(created_at_end_date=datetime.now())
+
+    filter_opts = DocumentReportFilter(updated_at_start_date=datetime(2021, 8, 1))
+    assert filter_opts['updatedAt']['to'] == todays_date
+    with pytest.raises(IndicoInputError):
+        DocumentReportFilter(updated_at_end_date=datetime.now())


### PR DESCRIPTION
- add default end date to document report filter, if start date is provided
- throw error if an end date is provided but the corresponding start date isn't
