### PR TITLE
ADD: created_by and deleted fields to document report

### DIFF
--- a/indico/queries/document_report.py
+++ b/indico/queries/document_report.py
@@ -27,12 +27,14 @@ class GetDocumentReport(PagedRequest):
               workflowId
               status
               createdAt
+              createdBy
               updatedAt
               updatedBy
               completedAt
               errors
               retrieved
               submissionId
+              deleted
               inputFiles{
                 filename
                 submissionId

--- a/indico/types/document_report.py
+++ b/indico/types/document_report.py
@@ -21,10 +21,12 @@ class DocumentReport(BaseType):
     submission_id: int
     status: str
     created_at: str
+    created_by: str
     updated_at: str
     updated_by: str
     completed_at: str
     errors: str
     retrieved: bool
     input_files: List[InputFile]
+    deleted: bool
 


### PR DESCRIPTION
`createdBy` and `deleted` are required as part of the weather station reporting, and they're exposed via the api but not the SDK. this PR adds them to the sdk call.
