### PR TITLE
ADD id for sub file in doc report

### DIFF
--- a/indico/queries/document_report.py
+++ b/indico/queries/document_report.py
@@ -36,7 +36,9 @@ class GetDocumentReport(PagedRequest):
               submissionId
               deleted
               inputFiles{
+                id
                 filename
+                filepath
                 submissionId
                 fileSize
                 numPages

--- a/indico/types/document_report.py
+++ b/indico/types/document_report.py
@@ -1,13 +1,7 @@
 from typing import List
 
 from indico.types import BaseType
-
-
-class InputFile(BaseType):
-    filename: str
-    submission_id: int
-    num_pages: int
-    file_size: int
+from indico.types import SubmissionFile
 
 
 class DocumentReport(BaseType):
@@ -27,6 +21,6 @@ class DocumentReport(BaseType):
     completed_at: str
     errors: str
     retrieved: bool
-    input_files: List[InputFile]
+    input_files: List[SubmissionFile]
     deleted: bool
 

--- a/tests/integration/queries/test_document_report.py
+++ b/tests/integration/queries/test_document_report.py
@@ -15,6 +15,10 @@ def test_fetch_docs(indico):
     assert len(document_report) > 0
     assert isinstance(document_report[0].input_files[0].num_pages, int)
     assert isinstance(document_report[0].input_files[0].file_size, int)
+    assert isinstance(document_report[0].input_files[0].id, int)
+    assert isinstance(document_report[0].input_files[0].submission_id, int)
+    assert document_report[0].input_files[0].filename
+
 
 
 def test_fetch_docs_limit(indico):

--- a/tests/integration/queries/test_document_report.py
+++ b/tests/integration/queries/test_document_report.py
@@ -20,7 +20,6 @@ def test_fetch_docs(indico):
     assert document_report[0].input_files[0].filename
 
 
-
 def test_fetch_docs_limit(indico):
     client = IndicoClient()
     filter_opts = DocumentReportFilter(


### PR DESCRIPTION
Include the submission file id in the document report, so we can differentiate between different files with the same name
