### PR TITLE
[CAT-515] FIX: force decompress when deserializing if url ends in gz

### DIFF
--- a/indico/http/client.py
+++ b/indico/http/client.py
@@ -1,6 +1,5 @@
 import http.cookiejar
 import logging
-from collections import defaultdict
 from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
@@ -149,15 +148,8 @@ class HTTPClient:
                 **new_kwargs,
             )
 
-        # code, api_response =
-        url_parts = path.split(".")
-        json = False
-        if len(url_parts) > 1 and (url_parts[-1] == "json" or url_parts[-2] == "json"):
-            json = True
-
-        decompress = False
-        if len(url_parts) > 1 and (url_parts[-1] == "gz"):
-            decompress = True
+        json: bool = ".json" in Path(path).suffixes
+        decompress: bool = Path(path).suffix == ".gz"
 
         # If auth expired refresh
         if response.status_code == 401 and not _refreshed:

--- a/indico/http/client.py
+++ b/indico/http/client.py
@@ -155,6 +155,10 @@ class HTTPClient:
         if len(url_parts) > 1 and (url_parts[-1] == "json" or url_parts[-2] == "json"):
             json = True
 
+        decompress = False
+        if len(url_parts) > 1 and (url_parts[-1] == "gz"):
+            decompress = True
+
         # If auth expired refresh
         if response.status_code == 401 and not _refreshed:
             self.get_short_lived_access_token()
@@ -172,7 +176,7 @@ class HTTPClient:
                 code=response.status_code
             )
 
-        content = deserialize(response, force_json=json)
+        content = deserialize(response, force_json=json, force_decompress=decompress)
 
         if response.status_code >= 400:
             if isinstance(content, dict):

--- a/indico/http/serialization.py
+++ b/indico/http/serialization.py
@@ -21,14 +21,10 @@ def decompress(response):
     return gzip.decompress(value)
 
 
-def raw_bytes(content, *args, **kwargs):
-    return content
-
-
-def deserialize(response, force_json=False):
+def deserialize(response, force_json=False, force_decompress=False):
     content_type, params = cgi.parse_header(response.headers.get("Content-Type"))
 
-    if content_type in ["application/x-gzip", "application/gzip"]:
+    if force_decompress or content_type in ["application/x-gzip", "application/gzip"]:
         content = decompress(response)
     else:
         content = response.content
@@ -47,6 +43,10 @@ def deserialize(response, force_json=False):
             content_type, charset, content.decode("ascii", "ignore")
         )
 
+
+
+def raw_bytes(content, *args, **kwargs):
+    return content
 
 def msgpack_deserialization(content, charset):
     return msgpack.unpackb(content)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,7 @@ logging.getLogger("indico").setLevel(logging.DEBUG)
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--host", action="store", default="dev.indico.io", help="indico ipa host"
+        "--host", action="store", default="dev-ci.us-east-2.indico-dev.indico.io", help="indico ipa host"
     )
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,8 +2,6 @@ import logging
 import pytest
 import os
 
-from indico.config import IndicoConfig
-
 logging.getLogger("indico").setLevel(logging.DEBUG)
 
 


### PR DESCRIPTION
In 5.x, the storage object returned by Document Extraction has a content type of `application/x-gzip`, but in 6.0 the content type is `binary/octet-stream`.

Since we can't always tell by the content type if the response needs to be decompressed, check the request URL and decompress the response if need be.