### PR TITLE
[CAT-510] FIX: add output nodes to workflow created during integration tests

### DIFF
--- a/tests/integration/data/datasets.py
+++ b/tests/integration/data/datasets.py
@@ -29,7 +29,14 @@ def airlines_dataset(indico):
 def airlines_workflow(indico, airlines_dataset: Dataset):
     client = IndicoClient()
     workflowreq = CreateWorkflow(dataset_id=airlines_dataset.id, name=f"AirlineComplaints-test-{int(time.time())}")
-    response = client.call(workflowreq)
+    wf = client.call(workflowreq)
+    # add default output node
+    client.call(_AddWorkflowComponent(after_component_id=wf.component_by_type("OUTPUT_JSON_FORMATTER").id,
+        component="{\"component_type\":\"default_output\",\"config\":{}}",
+        workflow_id=wf.id,
+        after_component_link=None
+    ))
+    response = client.call(GetWorkflow(workflow_id=wf.id))
 
     return response
 


### PR DESCRIPTION
This change makes it so the integration tests that work for 5.x also work for 6.0. Comparison between the two sets of test [here](https://docs.google.com/spreadsheets/d/1-TUeCZrj4ylJarPwRd5kRQwLD8XZt56dvmGyMo9oN8k/edit#gid=629986350)