### PR TITLE
[CAT-633] FIX: document extraction image test

### DIFF
--- a/tests/integration/queries/test_document.py
+++ b/tests/integration/queries/test_document.py
@@ -139,11 +139,10 @@ def test_document_extraction_batched(indico):
         assert isinstance(job.result["url"], str)
 
 
-def test_document_extraction_thumbnails(indico):
+def test_document_extraction_images(indico):
     client = IndicoClient()
     dataset_filepath = str(Path(__file__).parents[1]) + "/data/mock.pdf"
-
-    jobs = client.call(DocumentExtraction(files=[dataset_filepath]))
+    jobs = client.call(DocumentExtraction(files=[dataset_filepath], json_config='{"preset_config": "simple"}'))
 
     assert len(jobs) == 1
     job = jobs[0]


### PR DESCRIPTION
The test for retrieving images from document extraction OCR output has been failing since 5.x. As of 5.x, the default OCR config no longer includes returning the image link. This PR updates the test to use the simple config, which does include image links. 
