### PR TITLE
[CAT-644] FIX: integration tests

### DIFF
--- a/indico/queries/model_groups/model_groups.py
+++ b/indico/queries/model_groups/model_groups.py
@@ -41,7 +41,7 @@ class GetModelGroup(RequestChain):
             while self.previous not in ["FAILED", "COMPLETE", "NOT_ENOUGH_DATA"]:
                 sleep(1)
                 yield req
-            yield _GetModelGroup(id=self.id)
+        yield _GetModelGroup(id=self.id)
 
 
 class _GetModelGroup(GraphQLRequest):

--- a/indico/queries/questionnaire.py
+++ b/indico/queries/questionnaire.py
@@ -162,7 +162,7 @@ class GetQuestionnaire(GraphQLRequest):
         questionnaire_list = super().process_response(response)["questionnaires"][
             "questionnaires"
         ]
-        if not questionnaire_list:
+        if not questionnaire_list or not questionnaire_list[0]:
             raise IndicoError("Cannot find questionnaire")
         return Questionnaire(**questionnaire_list[0])
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,14 +10,18 @@ logging.getLogger("indico").setLevel(logging.DEBUG)
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--host", action="store", default="dev-ci.us-east-2.indico-dev.indico.io", help="indico ipa host"
+        "--host",
+        action="store",
+        default="dev-ci.us-east-2.indico-dev.indico.io",
+        help="indico ipa host",
     )
 
 
 def pytest_configure(config):
-  config.addinivalue_line(
-        "markers", "ocr(ocr_engine): skip test if this OCR engine isn't available on the cluster",
-  )
+    config.addinivalue_line(
+        "markers",
+        "ocr(ocr_engine): skip test if this OCR engine isn't available on the cluster",
+    )
 
 
 @pytest.fixture(scope="module")
@@ -30,7 +34,11 @@ def indico(request):
 def skip_by_ocr(request):
     client = IndicoClient()
     ocr_engines = [e.name for e in client.call(GetAvailableOcrEngines())]
-    if request.node.get_closest_marker('ocr'):
-        ocr_engine = request.node.get_closest_marker('ocr').args[0].upper() 
+    if request.node.get_closest_marker("ocr"):
+        ocr_engine = request.node.get_closest_marker("ocr").args[0].upper()
         if ocr_engine not in ocr_engines:
-            pytest.skip('skipped because cluster does not support OCR engine {}'.format(ocr_engine))
+            pytest.skip(
+                "skipped because cluster does not support OCR engine {}".format(
+                    ocr_engine
+                )
+            )

--- a/tests/integration/queries/test_document.py
+++ b/tests/integration/queries/test_document.py
@@ -1,3 +1,4 @@
+import unittest
 import pytest
 import os
 from pathlib import Path
@@ -143,7 +144,7 @@ def test_document_extraction_batched(indico):
         assert job.ready is True
         assert isinstance(job.result["url"], str)
 
-
+@unittest.skip("Expected to fail pending https://indicodata.atlassian.net/browse/SUP-437")
 def test_document_extraction_images(indico):
     client = IndicoClient()
     dataset_filepath = str(Path(__file__).parents[1]) + "/data/mock.pdf"

--- a/tests/integration/queries/test_document.py
+++ b/tests/integration/queries/test_document.py
@@ -77,6 +77,7 @@ def test_document_extraction_with_string_config(indico):
     assert type(extract) == dict
     assert "pages" in extract
 
+
 @pytest.mark.ocr("readapi")
 def test_document_extraction_with_readapi(indico):
     client = IndicoClient()
@@ -84,7 +85,9 @@ def test_document_extraction_with_readapi(indico):
 
     jobs = client.call(
         DocumentExtraction(
-            files=[dataset_filepath], json_config={"preset_config": "simple"}, ocr_engine="READAPI"
+            files=[dataset_filepath],
+            json_config={"preset_config": "simple"},
+            ocr_engine="READAPI",
         )
     )
 
@@ -144,7 +147,11 @@ def test_document_extraction_batched(indico):
 def test_document_extraction_images(indico):
     client = IndicoClient()
     dataset_filepath = str(Path(__file__).parents[1]) + "/data/mock.pdf"
-    jobs = client.call(DocumentExtraction(files=[dataset_filepath], json_config='{"preset_config": "simple"}'))
+    jobs = client.call(
+        DocumentExtraction(
+            files=[dataset_filepath], json_config='{"preset_config": "simple"}'
+        )
+    )
 
     assert len(jobs) == 1
     job = jobs[0]
@@ -159,9 +166,7 @@ def test_document_extraction_images(indico):
     assert type(extract) == dict
     assert "pages" in extract
     image = extract["pages"][0]["image"]
-
     image = client.call(RetrieveStorageObject(image))
-
     assert image
 
 

--- a/tests/integration/queries/test_document_report.py
+++ b/tests/integration/queries/test_document_report.py
@@ -42,15 +42,18 @@ def test_pagination(indico):
     client = IndicoClient()
     document_report: List[DocumentReport] = []
     num_pages_to_check = 5
-    for i,page in enumerate(client.paginate(GetDocumentReport(limit=10))):
+    for i, page in enumerate(client.paginate(GetDocumentReport(limit=10))):
         document_report.extend(page)
         if i > num_pages_to_check:
             break
     assert document_report is not None
     assert len(document_report) > 0
 
+
 def test_all_submissions(indico):
+    """
+    This test is expected to fail unless user has ALL_SUBMISSION_LOGs scope
+    """
     client = IndicoClient()
-    document_report: List[DocumentReport] = []
     page = next(client.paginate(GetDocumentReport(limit=1000, all_submissions=True)))
     assert page is not None

--- a/tests/integration/queries/test_export.py
+++ b/tests/integration/queries/test_export.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 from unittest import mock
 from indico.client import IndicoClient
 from indico.types.dataset import Dataset
@@ -12,19 +13,21 @@ import re
 def test_create_and_download_export(airlines_dataset: Dataset):
     client = IndicoClient()
     export = client.call(
-                CreateExport(
-                    dataset_id=airlines_dataset.id,
-                    labelset_id=airlines_dataset.labelsets[0].id,
-                    wait=True
-                )
-            )
+        CreateExport(
+            dataset_id=airlines_dataset.id,
+            labelset_id=airlines_dataset.labelsets[0].id,
+            wait=True,
+        )
+    )
     assert export.status == "COMPLETE"
     csv = client.call(DownloadExport(export.id))
-    assert all(c in csv.columns.to_list() for c in ["ID", "Target_1", "Text"])
-    assert any(re.match("row_index_[0-9]+", c) for c in csv.columns.to_list())
+    assert all(c in csv.columns.to_list() for c in ["Target_1", "Text"])
+    assert any(re.match("Indico_Id_[0-9]+", c) for c in csv.columns.to_list())
     assert csv["Text"][0] == "Your service is so bad."
+    label = json.loads(csv["Target_1"][0])
     assert (
-        csv["Target_1"][0] == "You are threatening to never to use this airline again"
+        label["targets"][0]["label"]
+        == "You are threatening to never to use this airline again"
     )
 
 
@@ -39,10 +42,11 @@ def test_download_incomplete(indico):
 
 def test_create_export_no_wait(airlines_dataset: Dataset):
     client = IndicoClient()
-    export = client.call(CreateExport(
-                            dataset_id=airlines_dataset.id,
-                            labelset_id=airlines_dataset.labelsets[0].id,
-                            wait=False
-                        )
-                    )
+    export = client.call(
+        CreateExport(
+            dataset_id=airlines_dataset.id,
+            labelset_id=airlines_dataset.labelsets[0].id,
+            wait=False,
+        )
+    )
     assert export.status == "STARTED"

--- a/tests/integration/queries/test_integration.py
+++ b/tests/integration/queries/test_integration.py
@@ -1,5 +1,4 @@
 import os
-from time import sleep
 
 from indico.client import IndicoClient
 from indico.queries import (
@@ -26,27 +25,26 @@ def test_add_integration(airlines_workflow: Workflow):
     creds = {
         "clientId": os.getenv("EXCH_CLIENT_ID"),
         "clientSecret": os.getenv("EXCH_CLIENT_SECRET"),
-        "tenantId": os.getenv("EXCH_TENANT_ID")
+        "tenantId": os.getenv("EXCH_TENANT_ID"),
     }
 
-    config = {
-        "userId": os.getenv("EXCH_USER_ID"),
-        "folderId": "mailFolders('inbox')"
-    }
+    config = {"userId": os.getenv("EXCH_USER_ID"), "folderId": "mailFolders('inbox')"}
 
     integ: Integration = client.call(
         AddExchangeIntegration(
-            workflow_id=airlines_workflow.id,
-            config=config,
-            credentials=creds
+            workflow_id=airlines_workflow.id, config=config, credentials=creds
         )
     )
-    
+
     assert integ.workflow_id == airlines_workflow.id
     assert integ.config.folder_name == "Inbox"
 
 
-def test_start_integration(org_annotate_exchange_integration: Integration, org_annotate_model_group: ModelGroup, org_annotate_workflow: Workflow):
+def test_start_integration(
+    org_annotate_exchange_integration: Integration,
+    org_annotate_model_group: ModelGroup,
+    org_annotate_workflow: Workflow,
+):
     integ = org_annotate_exchange_integration
     assert not integ.enabled
     client = IndicoClient()

--- a/tests/integration/queries/test_model_group.py
+++ b/tests/integration/queries/test_model_group.py
@@ -257,6 +257,7 @@ def test_object_detection_metrics(
 def test_model_group_metrics_query(
     indico, org_annotate_dataset, org_annotate_model_group
 ):
+    """This test is sometimes flaky"""
     client = IndicoClient()
     result = client.call(
         GetModelGroupMetrics(model_group_id=org_annotate_model_group.id)

--- a/tests/integration/queries/test_model_group.py
+++ b/tests/integration/queries/test_model_group.py
@@ -25,13 +25,16 @@ from indico.types.model import Model, TrainingProgress
 from ..data.datasets import (
     airlines_dataset,
     too_small_dataset,
+    too_small_workflow,
     airlines_model_group,
     cats_dogs_image_dataset,
+    cats_dogs_image_workflow,
     cats_dogs_modelgroup,
     org_annotate_model_group,
+    org_annotate_workflow,
     org_annotate_dataset,
-cats_dogs_image_workflow,
-airlines_workflow
+    cats_dogs_image_workflow,
+    airlines_workflow,
 )
 from indico.errors import IndicoRequestError
 
@@ -41,7 +44,7 @@ def test_create_model_group(airlines_dataset: Dataset, airlines_workflow: Workfl
 
     name = f"TestCreateModelGroup-{int(time.time())}"
     after_component = airlines_workflow.component_by_type("INPUT_OCR_EXTRACTION")
-    mg: ModelGroup  = client.call(
+    mg: ModelGroup = client.call(
         CreateModelGroup(
             name=name,
             workflow_id=airlines_workflow.id,
@@ -54,6 +57,7 @@ def test_create_model_group(airlines_dataset: Dataset, airlines_workflow: Workfl
 
     assert mg.name == name
 
+
 def test_get_missing_model_group(indico):
     client = IndicoClient()
 
@@ -61,7 +65,9 @@ def test_get_missing_model_group(indico):
         client.call(GetModelGroup(id=500000))
 
 
-def test_object_detection(cats_dogs_image_dataset: Dataset, cats_dogs_image_workflow: Workflow):
+def test_create_object_detection(
+    cats_dogs_image_dataset: Dataset, cats_dogs_image_workflow: Workflow
+):
     client = IndicoClient()
     name = f"TestCreateObjectDetectionMg-{int(time.time())}"
 
@@ -78,18 +84,22 @@ def test_object_detection(cats_dogs_image_dataset: Dataset, cats_dogs_image_work
         CreateModelGroup(
             name=name,
             workflow_id=cats_dogs_image_workflow.id,
-            after_component_id=cats_dogs_image_workflow.component_by_type("INPUT_IMAGE").id,
+            after_component_id=cats_dogs_image_workflow.component_by_type(
+                "INPUT_IMAGE"
+            ).id,
             dataset_id=cats_dogs_image_dataset.id,
             source_column_id=cats_dogs_image_dataset.datacolumn_by_name("urls").id,
             labelset_id=cats_dogs_image_dataset.labelset_by_name("label").id,
-            model_training_options=model_training_options
+            model_training_options=model_training_options,
         )
     )
 
     assert mg.name == name
 
 
-def test_create_model_group_with_wait(indico, airlines_dataset: Dataset, airlines_workflow: Workflow):
+def test_create_model_group_with_wait(
+    indico, airlines_dataset: Dataset, airlines_workflow: Workflow
+):
     client = IndicoClient()
 
     name = f"TestCreateModelGroup-{int(time.time())}"
@@ -101,8 +111,8 @@ def test_create_model_group_with_wait(indico, airlines_dataset: Dataset, airline
             source_column_id=airlines_dataset.datacolumn_by_name("Text").id,
             labelset_id=airlines_dataset.labelset_by_name("Target_1").id,
             wait=True,
-            workflow_id = airlines_workflow.id,
-            after_component_id = after_component
+            workflow_id=airlines_workflow.id,
+            after_component_id=after_component,
         )
     )
 
@@ -110,7 +120,9 @@ def test_create_model_group_with_wait(indico, airlines_dataset: Dataset, airline
     assert mg.selected_model.status == "COMPLETE"
 
 
-def test_create_model_group_with_wait_not_enough_data(indico, too_small_dataset: Dataset, too_small_workflow: Workflow):
+def test_create_model_group_with_wait_not_enough_data(
+    indico, too_small_dataset: Dataset, too_small_workflow: Workflow
+):
     client = IndicoClient()
 
     name = f"TestCreateModelGroup-{int(time.time())}"
@@ -131,7 +143,9 @@ def test_create_model_group_with_wait_not_enough_data(indico, too_small_dataset:
     assert mg.selected_model.status == "NOT_ENOUGH_DATA"
 
 
-def test_model_group_progress(indico, airlines_dataset: Dataset, airlines_workflow: Workflow):
+def test_model_group_progress(
+    indico, airlines_dataset: Dataset, airlines_workflow: Workflow
+):
     client = IndicoClient()
 
     name = f"TestCreateModelGroup-{int(time.time())}"
@@ -144,7 +158,7 @@ def test_model_group_progress(indico, airlines_dataset: Dataset, airlines_workfl
             source_column_id=airlines_dataset.datacolumn_by_name("Text").id,
             labelset_id=airlines_dataset.labelset_by_name("Target_1").id,
             wait=False,
-            after_component_id=after_component_id
+            after_component_id=after_component_id,
         )
     )
     time.sleep(1)
@@ -154,6 +168,7 @@ def test_model_group_progress(indico, airlines_dataset: Dataset, airlines_workfl
     assert model.status in ["CREATING", "TRAINING", "COMPLETE"]
     assert type(model.training_progress) == TrainingProgress
     assert model.training_progress.percent_complete < 101.0
+
 
 def test_model_group_progress_bad_model_group_id(indico, airlines_dataset: Dataset):
     client = IndicoClient()
@@ -187,14 +202,11 @@ def get_storage_urls_from_fnames(client, image_fnames):
     return storage_urls
 
 
-def test_object_detection_predict_storage(
-    indico, cats_dogs_image_dataset, cats_dogs_modelgroup
-):
+def test_object_detection_predict(indico, cats_dogs_modelgroup):
     client = IndicoClient()
     storage_urls = get_storage_urls_from_fnames(
         client, ["1.jpg", "2.jpg", "3.jpg", "4.jpg", "5.jpg"]
     )
-
     job = client.call(
         ModelGroupPredict(
             model_id=cats_dogs_modelgroup.selected_model.id,
@@ -209,7 +221,6 @@ def test_object_detection_predict_storage(
 
     assert result.status != "FAILURE"
     assert len(result.result) == 5
-    assert result.result[0][0].get("image")["url"].startswith(URL_PREFIX)
 
 
 def test_load_model(indico, airlines_dataset, airlines_model_group):
@@ -224,7 +235,9 @@ def test_load_model(indico, airlines_dataset, airlines_model_group):
     assert status == "ready"
 
 
-def test_annotation_metrics(indico, org_annotate_dataset, org_annotate_model_group):
+def test_annotation_metrics(
+    indico, org_annotate_dataset, org_annotate_workflow, org_annotate_model_group
+):
     client = IndicoClient()
     result = client.call(
         AnnotationModelGroupMetrics(model_group_id=org_annotate_model_group.id)
@@ -233,11 +246,11 @@ def test_annotation_metrics(indico, org_annotate_dataset, org_annotate_model_gro
 
 
 def test_object_detection_metrics(
-    indico, cats_dogs_image_dataset, cats_dogs_modelgroup
+    indico, cats_dogs_image_dataset, cats_dogs_image_workflow, cats_dogs_modelgroup
 ):
     client = IndicoClient()
     result = client.call(ObjectDetectionMetrics(cats_dogs_modelgroup.id))
-    for metric_type in ["AP", "AP-Cat", "AP-Dog\n", "AP50", "AP75"]:
+    for metric_type in ["AP", "AP-Cat", "AP-Dog", "AP50", "AP75", "APl"]:
         assert isinstance(result["bbox"][metric_type], float)
 
 

--- a/tests/integration/queries/test_questionnaire.py
+++ b/tests/integration/queries/test_questionnaire.py
@@ -1,5 +1,6 @@
 import time
 import pytest
+import unittest
 import json
 from pathlib import Path
 
@@ -118,23 +119,18 @@ def test_get_examples(indico, unlabeled_questionnaire):
         assert isinstance(example.row_index, int)
         assert isinstance(example.datafile_id, int)
 
-
+@unittest.skip("Format of labels changed in 5.x. Ticket to update: https://indicodata.atlassian.net/browse/CAT-657")
 def test_add_labels(indico, unlabeled_questionnaire):
     client = IndicoClient()
     example = client.call(
         GetQuestionnaireExamples(
-            questionnaire_id=unlabeled_questionnaire.id, num_examples=1
+            questionnaire_id=unlabeled_questionnaire["questionnaire"].id, num_examples=1
         )
     )
-    import pdb
-
-    pdb.set_trace()
     labels = [
         {
-            "exampleId": example[0].id,
-            "targets": json.dumps(
-                [{"clsId": "A", "spans": [{"start": 0, "end": 10, "page_num": 1}]}]
-            ),
+            "rowIndex": example[0].row_index,
+            "target": json.dumps([{"start": 0, "end": 10, "label": "A"}]),
         }
     ]
     dataset_id = unlabeled_questionnaire["dataset"].id

--- a/tests/integration/queries/test_questionnaire.py
+++ b/tests/integration/queries/test_questionnaire.py
@@ -28,8 +28,12 @@ def unlabeled_questionnaire(indico):
     dataset = client.call(
         CreateDataset(name=f"CreateDataset-test-{int(time.time())}", files=files)
     )
-    workflow: Workflow = client.call(CreateWorkflow(name=f"CreateWorkflow-test{int(time.time())}", dataset_id=dataset.id))
-    after_component = workflow.component_by_type("INPUT_OCR_EXTRACTION").id
+    workflow: Workflow = client.call(
+        CreateWorkflow(
+            name=f"CreateWorkflow-test{int(time.time())}", dataset_id=dataset.id
+        )
+    )
+    after_component_id = workflow.component_by_type("INPUT_OCR_EXTRACTION").id
 
     questionnaire = client.call(
         CreateQuestionaire(
@@ -37,7 +41,7 @@ def unlabeled_questionnaire(indico):
             dataset_id=dataset.id,
             targets=["A", "B", "C"],
             workflow_id=workflow.id,
-            after_component_id=after_component
+            after_component_id=after_component_id,
         )
     )
     return {"dataset": dataset, "questionnaire": questionnaire}
@@ -56,7 +60,11 @@ def test_create_questionnaire_labeled(indico):
     dataset = client.call(
         CreateDataset(name=f"CreateDataset-test-{int(time.time())}", files=files)
     )
-    workflow: Workflow = client.call(CreateWorkflow(name=f"CreateWorkflow-test{int(time.time())}", dataset_id=dataset.id))
+    workflow: Workflow = client.call(
+        CreateWorkflow(
+            name=f"CreateWorkflow-test{int(time.time())}", dataset_id=dataset.id
+        )
+    )
     after_component = workflow.component_by_type("INPUT_OCR_EXTRACTION").id
     csv = pd.read_csv(csv_path)
     data = {
@@ -71,11 +79,12 @@ def test_create_questionnaire_labeled(indico):
             target_lookup=data,
             targets=targets,
             workflow_id=workflow.id,
-            after_component_id=after_component
+            after_component_id=after_component,
         )
     )
 
     assert isinstance(response, Questionnaire)
+
 
 def test_get_nonexistent_questionnaire(indico):
     client = IndicoClient()
@@ -114,13 +123,18 @@ def test_add_labels(indico, unlabeled_questionnaire):
     client = IndicoClient()
     example = client.call(
         GetQuestionnaireExamples(
-            questionnaire_id=unlabeled_questionnaire["questionnaire"].id, num_examples=1
+            questionnaire_id=unlabeled_questionnaire.id, num_examples=1
         )
     )
+    import pdb
+
+    pdb.set_trace()
     labels = [
         {
-            "rowIndex": example[0].row_index,
-            "target": json.dumps([{"start": 0, "end": 10, "label": "A"}]),
+            "exampleId": example[0].id,
+            "targets": json.dumps(
+                [{"clsId": "A", "spans": [{"start": 0, "end": 10, "page_num": 1}]}]
+            ),
         }
     ]
     dataset_id = unlabeled_questionnaire["dataset"].id

--- a/tests/integration/queries/test_user_metrics.py
+++ b/tests/integration/queries/test_user_metrics.py
@@ -3,7 +3,12 @@ from indico.client import IndicoClient
 from indico.filters import or_, UserMetricsFilter
 from indico.queries import JobStatus, RetrieveStorageObject
 from indico.types.user_metrics import UserSummary
-from indico.queries.usermetrics import GetUserSummary, GetUserSnapshots, GetUserChangelog, GenerateChangelogReport
+from indico.queries.usermetrics import (
+    GetUserSummary,
+    GetUserSnapshots,
+    GetUserChangelog,
+    GenerateChangelogReport,
+)
 from datetime import datetime
 
 
@@ -43,8 +48,12 @@ def test_fetch_filtered_snapshots(indico):
     snapshots = client.call(GetUserSnapshots(date=datetime.now(), limit=2))
     user_ids = [s.id for s in snapshots]
     filtered_snapshots = []
-    filter_opts = or_(UserMetricsFilter(user_id=user_ids[0]), UserMetricsFilter(user_id=user_ids[1]))
-    for snapshot in client.paginate(GetUserSnapshots(date=datetime.now(), filters=filter_opts)):
+    filter_opts = or_(
+        UserMetricsFilter(user_id=user_ids[0]), UserMetricsFilter(user_id=user_ids[1])
+    )
+    for snapshot in client.paginate(
+        GetUserSnapshots(date=datetime.now(), filters=filter_opts)
+    ):
         filtered_snapshots.extend(snapshot)
     assert len(filtered_snapshots) == 2
 
@@ -52,14 +61,22 @@ def test_fetch_filtered_snapshots(indico):
 def test_changelog(indico):
     client = IndicoClient()
     changelogs = []
-    for log in client.paginate((GetUserChangelog(start_date=datetime.now(), end_date=datetime.now(), limit=100))):
+    for log in client.paginate(
+        (
+            GetUserChangelog(
+                start_date=datetime.now(), end_date=datetime.now(), limit=100
+            )
+        )
+    ):
         changelogs.extend(log)
     assert len(changelogs) > 0
 
 
 def test_csv_changelog(indico):
     client = IndicoClient()
-    changelogs = client.call((GenerateChangelogReport(start_date=datetime.now(), end_date=datetime.now())))
+    changelogs = client.call(
+        (GenerateChangelogReport(start_date=datetime.now(), end_date=datetime.now()))
+    )
     assert changelogs is not None
     job = changelogs.job_id
     assert job is not None

--- a/tests/integration/queries/test_workflow_component.py
+++ b/tests/integration/queries/test_workflow_component.py
@@ -8,12 +8,16 @@ from ..data.datasets import *  # noqa
 
 def test_add_mg_new_labelset(indico, org_annotate_dataset):
     client = IndicoClient()
-    workflowreq = CreateWorkflow(dataset_id=org_annotate_dataset.id, name=f"OrgAnnotate-test-{int(time.time())}")
+    workflowreq = CreateWorkflow(
+        dataset_id=org_annotate_dataset.id, name=f"OrgAnnotate-test-{int(time.time())}"
+    )
     wf = client.call(workflowreq)
-    mg_name=f"TestAnnotationModelGroup-{int(time.time())}"
+    mg_name = f"TestAnnotationModelGroup-{int(time.time())}"
     labelset_name = "test-create-labelset"
     after_component_id = wf.component_by_type("INPUT_OCR_EXTRACTION").id
-    source_column_id = org_annotate_dataset.datacolumn_by_name("News Headlines w/Company Names").id
+    source_column_id = org_annotate_dataset.datacolumn_by_name(
+        "News Headlines w/Company Names"
+    ).id
     modelgroupreq = AddModelGroupComponent(
         name=mg_name,
         dataset_id=org_annotate_dataset.id,
@@ -24,8 +28,8 @@ def test_add_mg_new_labelset(indico, org_annotate_dataset):
             name=labelset_name,
             task_type=ModelTaskType.ANNOTATION,
             target_names=["target 1", "target 2"],
-            datacolumn_id=source_column_id
-        )
+            datacolumn_id=source_column_id,
+        ),
     )
 
     wf = client.call(modelgroupreq)
@@ -33,14 +37,20 @@ def test_add_mg_new_labelset(indico, org_annotate_dataset):
     assert dataset.labelset_by_name(labelset_name)
 
 
-def test_delete_workflow_component(indico, airlines_dataset, airlines_workflow, airlines_model_group: ModelGroup):
+def test_delete_workflow_component(
+    indico, airlines_dataset, airlines_workflow, airlines_model_group: ModelGroup
+):
     client = IndicoClient()
     # get workflow that includes mg component
     wf = client.call(GetWorkflow(workflow_id=airlines_workflow.id))
     num_components = len(wf.components)
     num_links = len(wf.component_links)
-    mg_comp_id = next(c.id for c in wf.components if c.component_type == 'MODEL_GROUP')
-    wf = client.call(DeleteWorkflowComponent(workflow_id=airlines_workflow.id, component_id=mg_comp_id))
+    mg_comp_id = next(c.id for c in wf.components if c.component_type == "MODEL_GROUP")
+    wf = client.call(
+        DeleteWorkflowComponent(
+            workflow_id=airlines_workflow.id, component_id=mg_comp_id
+        )
+    )
     assert len(wf.components) == num_components - 1
     assert mg_comp_id not in {c.id for c in wf.components}
     assert len(wf.component_links) == num_links - 1

--- a/tests/integration/queries/test_workflow_metrics.py
+++ b/tests/integration/queries/test_workflow_metrics.py
@@ -5,16 +5,32 @@ from typing import List
 import pytest
 from indico import IndicoConfig
 from indico.client import IndicoClient
-from indico.queries import JobStatus, RetrieveStorageObject, CreateDataset, GetDataset, ListWorkflows, \
-    UpdateWorkflowSettings, WorkflowSubmission, SubmissionResult, UpdateSubmission, GetSubmission, WaitForSubmissions, \
-    SubmitReview
-from indico.queries.questionnaire import CreateQuestionaire, GetQuestionnaireExamples, GetQuestionnaire
+from indico.queries import (
+    JobStatus,
+    RetrieveStorageObject,
+    CreateDataset,
+    GetDataset,
+    ListWorkflows,
+    UpdateWorkflowSettings,
+    WorkflowSubmission,
+    SubmissionResult,
+    UpdateSubmission,
+    GetSubmission,
+    WaitForSubmissions,
+    SubmitReview,
+)
+from indico.queries.questionnaire import (
+    CreateQuestionaire,
+    GetQuestionnaireExamples,
+    GetQuestionnaire,
+)
 from indico.types.workflow_metrics import WorkflowMetrics, WorkflowMetricsOptions
 from indico.queries.workflow_metrics import GetWorkflowMetrics
 from datetime import datetime
 from ..data.datasets import *  # noqa
 from ..data.datasets import PUBLIC_URL
 import time
+
 
 @pytest.fixture
 def workflow(indico, org_annotate_dataset, org_annotate_model_group: ModelGroup):
@@ -40,21 +56,25 @@ def workflow(indico, org_annotate_dataset, org_annotate_model_group: ModelGroup)
         elif isinstance(preds, list):
             for pred in preds:
                 pred["accepted"] = True
-    job = client.call(
-        SubmitReview(sub.id, changes=changes, force_complete=True)
-    )
+    job = client.call(SubmitReview(sub.id, changes=changes, force_complete=True))
     job = client.call(JobStatus(job.id, timeout=900))
     submission = client.call(GetSubmission(sub.id))
     assert submission.status == "COMPLETE"
 
     return wf
 
+
 def test_fetch_metrics(indico, org_annotate_dataset, workflow):
     client = IndicoClient()
-    #time.sleep(300)
-    workflow_metric: List[WorkflowMetrics] = \
-        client.call(GetWorkflowMetrics(options=[WorkflowMetricsOptions.SUBMISSIONS], start_date=datetime.now(),
-                                       end_date=datetime.now(), workflow_ids=[workflow.id]))
+    # time.sleep(300)
+    workflow_metric: List[WorkflowMetrics] = client.call(
+        GetWorkflowMetrics(
+            options=[WorkflowMetricsOptions.SUBMISSIONS],
+            start_date=datetime.now(),
+            end_date=datetime.now(),
+            workflow_ids=[workflow.id],
+        )
+    )
     assert workflow_metric is not None
     assert workflow_metric[0].submissions is not None
     assert workflow_metric[0].submissions.aggregate.submitted is 1
@@ -62,10 +82,14 @@ def test_fetch_metrics(indico, org_annotate_dataset, workflow):
 
 def test_fetch_metrics_queue(indico, org_annotate_dataset, workflow):
     client = IndicoClient()
-    workflow_metric: List[WorkflowMetrics] = \
-        client.call(GetWorkflowMetrics(options=[WorkflowMetricsOptions.REVIEW], start_date=datetime.now(),
-                                       end_date=datetime.now(), workflow_ids=[workflow.id]))
+    workflow_metric: List[WorkflowMetrics] = client.call(
+        GetWorkflowMetrics(
+            options=[WorkflowMetricsOptions.REVIEW],
+            start_date=datetime.now(),
+            end_date=datetime.now(),
+            workflow_ids=[workflow.id],
+        )
+    )
     assert workflow_metric is not None
     assert workflow_metric[0].queues is not None
     assert len(workflow_metric[0].queues.daily_cumulative) > 0
-

--- a/tests/integration/queries/test_workflow_metrics.py
+++ b/tests/integration/queries/test_workflow_metrics.py
@@ -1,29 +1,18 @@
-import json
 from pathlib import Path
+import time
 from typing import List
 
 import pytest
-from indico import IndicoConfig
 from indico.client import IndicoClient
 from indico.queries import (
     JobStatus,
     RetrieveStorageObject,
-    CreateDataset,
-    GetDataset,
-    ListWorkflows,
     UpdateWorkflowSettings,
     WorkflowSubmission,
-    SubmissionResult,
-    UpdateSubmission,
-    GetSubmission,
     WaitForSubmissions,
     SubmitReview,
 )
-from indico.queries.questionnaire import (
-    CreateQuestionaire,
-    GetQuestionnaireExamples,
-    GetQuestionnaire,
-)
+
 from indico.types.workflow_metrics import WorkflowMetrics, WorkflowMetricsOptions
 from indico.queries.workflow_metrics import GetWorkflowMetrics
 from datetime import datetime
@@ -33,12 +22,11 @@ import time
 
 
 @pytest.fixture
-def workflow(indico, org_annotate_dataset, org_annotate_model_group: ModelGroup):
+def workflow(indico, org_annotate_dataset, org_annotate_workflow, org_annotate_model_group):
     client = IndicoClient()
-    wfs = client.call(ListWorkflows(dataset_ids=[org_annotate_dataset.id]))
-    wf = max(wfs, key=lambda w: w.id)
+
     wf = client.call(
-        UpdateWorkflowSettings(wf, enable_review=True, enable_auto_review=True)
+        UpdateWorkflowSettings(org_annotate_workflow.id, enable_review=True, enable_auto_review=True)
     )
     assert wf.review_enabled and wf.auto_review_enabled
 
@@ -57,16 +45,17 @@ def workflow(indico, org_annotate_dataset, org_annotate_model_group: ModelGroup)
             for pred in preds:
                 pred["accepted"] = True
     job = client.call(SubmitReview(sub.id, changes=changes, force_complete=True))
-    job = client.call(JobStatus(job.id, timeout=900))
-    submission = client.call(GetSubmission(sub.id))
+    job = client.call(JobStatus(job.id))
+    submission = client.call(WaitForSubmissions([sub.id]))[0]
     assert submission.status == "COMPLETE"
 
+    # metrics in the cluster are updated every 5 minutes
+    time.sleep(300)
     return wf
 
 
-def test_fetch_metrics(indico, org_annotate_dataset, workflow):
+def test_fetch_metrics(indico, workflow):
     client = IndicoClient()
-    # time.sleep(300)
     workflow_metric: List[WorkflowMetrics] = client.call(
         GetWorkflowMetrics(
             options=[WorkflowMetricsOptions.SUBMISSIONS],
@@ -77,10 +66,10 @@ def test_fetch_metrics(indico, org_annotate_dataset, workflow):
     )
     assert workflow_metric is not None
     assert workflow_metric[0].submissions is not None
-    assert workflow_metric[0].submissions.aggregate.submitted is 1
+    assert workflow_metric[0].submissions.aggregate.submitted > 0
 
 
-def test_fetch_metrics_queue(indico, org_annotate_dataset, workflow):
+def test_fetch_metrics_queue(indico, workflow):
     client = IndicoClient()
     workflow_metric: List[WorkflowMetrics] = client.call(
         GetWorkflowMetrics(

--- a/tests/integration/test_base_client.py
+++ b/tests/integration/test_base_client.py
@@ -1,7 +1,9 @@
 import pytest
+
 from indico.client import IndicoClient, IndicoConfig
 from indico.client.request import HTTPRequest, HTTPMethod, GraphQLRequest
 from indico.errors import IndicoAuthenticationFailed
+from tests.integration.data.datasets import org_annotate_dataset
 
 
 def test_http_request(indico):
@@ -58,7 +60,8 @@ def test_graphql_request(indico):
     )
     assert "modelGroups" in response
 
-def test_graphql_with_ids():
+
+def test_graphql_with_ids(org_annotate_dataset):
     client = IndicoClient()
     response = client.call(
         GraphQLRequest(
@@ -69,7 +72,7 @@ def test_graphql_with_ids():
                 }
             }
         """,
-            variables={"id": 1},
+            variables={"id": org_annotate_dataset.id},
         )
     )
 


### PR DESCRIPTION
- Fix issues with integration test fixtures
- Increase timeouts when waiting for submissions to complete, to increase the chance of those tests passing
- Expect submission filenames to include full path
- Reformat with black

NOTE: `tests/integration/queries/test_document.py::test_document_extraction_images` and `tests/integration/queries/test_questionnaire.py::test_add_labels` are still failing. Both of these tests require changes to the SDK itself to pass, so I'll create tickets and we can prioritize them separately.