### PR TITLE
Add missing required `error` argument to `IndicoRequestError()`

### DIFF
--- a/indico/http/client.py
+++ b/indico/http/client.py
@@ -165,7 +165,9 @@ class HTTPClient:
 
         if response.status_code >= 500:
             raise IndicoRequestError(
-                code=response.status_code
+                code=response.status_code,
+                error=response.reason,
+                extras=repr(response.content),
             )
 
         content = deserialize(response, force_json=json, force_decompress=decompress)


### PR DESCRIPTION
## Summary

This fixes a bug where 5XX response status codes raise `TypeError: IndicoRequestError.__init__() missing 1 required positional argument: 'error'` instead of an instance of `IndicoRequestError`.

Also includes the response content bytes as extras to aid debugging.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] Code has been self-reviewed
- [x] My changes generate no new warnings