### PR TITLE
fix create custom blueprint call and add labels test

### DIFF
--- a/indico/queries/custom_blueprint.py
+++ b/indico/queries/custom_blueprint.py
@@ -109,7 +109,7 @@ mutation createCustomBP(
             raise IndicoInputError(
                 "'component_family' must be of type indico.types.workflows.ComponentFamily"
             )
-        if component_family.name not in SUPPORTED_CUSTOM_COMPONENT_FAMILIES:
+        if component_family not in SUPPORTED_CUSTOM_COMPONENT_FAMILIES:
             raise IndicoInputError(
                 f"component_family must be one of {', '.join([cf.name for cf in SUPPORTED_CUSTOM_COMPONENT_FAMILIES])}"
             )

--- a/tests/integration/queries/test_questionnaire.py
+++ b/tests/integration/queries/test_questionnaire.py
@@ -133,7 +133,7 @@ def test_add_labels(indico, unlabeled_questionnaire):
     )
     targets = [
         {
-            "clsId": next(t for t in targets if t.name == "A"),
+            "clsId": next(t.id for t in targets if t.name == "A"),
             "spans": [{"start": 0, "end": 10, "pageNum": 0}],
         }
     ]
@@ -159,9 +159,3 @@ def test_add_labels(indico, unlabeled_questionnaire):
     )
     assert questionnaire.num_total_examples == 3
     assert questionnaire.num_fully_labeled == 1
-
-
-def get_cls_id(cls_name: str, targets: t.List[TargetName]) -> int:
-    for target in targets:
-        if target.name == cls_name:
-            return target.id


### PR DESCRIPTION
Discovered two bug while running tests for 6.3:

-  CreateCustomClueprint type checking error
- type error in AddLabels integration test