### PR TITLE
[CAT-803] Add dockerfile for container that generates markdown docs

### DIFF
--- a/docs.Dockerfile
+++ b/docs.Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.9.15
+
+COPY . /indico-client
+WORKDIR /indico-client
+RUN python3 setup.py install
+RUN apt-get update && apt-get install python3-sphinx -y 
+RUN pip install sphinx-markdown-builder==0.6.5 sphinx-autodoc-typehints==1.24.0
+# docs are outputted to ./markdown
+RUN sphinx-build -M markdown ./docsrc .

--- a/docs.Dockerfile
+++ b/docs.Dockerfile
@@ -4,6 +4,4 @@ COPY . /indico-client
 WORKDIR /indico-client
 RUN python3 setup.py install
 RUN apt-get update && apt-get install python3-sphinx -y 
-RUN pip install sphinx-markdown-builder==0.6.5 sphinx-autodoc-typehints==1.24.0
-# docs are outputted to ./markdown
-RUN sphinx-build -M markdown ./docsrc .
+CMD ["sleep", "infinity"]

--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -19,11 +19,11 @@ sys.path.insert(0, os.path.abspath("../"))
 # -- Project information -----------------------------------------------------
 
 project = "Indico Python Client"
-copyright = "2020, Indico"
+copyright = "2023, Indico"
 author = "Indico"
 
 # The full version, including alpha/beta/rc tags
-release = "3.1.0"
+release = "6.0.0"
 
 
 # -- General configuration ---------------------------------------------------
@@ -32,10 +32,10 @@ release = "3.1.0"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinx_rtd_theme",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx_autodoc_typehints",
+    "sphinx_markdown_builder"
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -45,22 +45,3 @@ templates_path = ["_templates"]
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
-
-
-# -- Options for HTML output -------------------------------------------------
-
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
-html_theme = "sphinx_rtd_theme"
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
-html_style = "css/indicotheme.css"
-html_logo = "./_static/logo-blue-bkgd.png"
-html_favicon = "./_static/favicon.png"
-html_theme_options = {
-    "style_nav_header_background": "linear-gradient(to right top,#2c4658,#2f5f76,#2b7992,#2094ad,#04b1c6)"
-}

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+pip install sphinx-markdown-builder==0.6.5 sphinx-autodoc-typehints==1.24.0
+# docs are outputted to ./markdown
+sphinx-build -M markdown ./docsrc .


### PR DESCRIPTION
- Add separate dockerfile specifically for building docs
- Modify sphinx config to generate markdown instead of HTML
    - Use the `sphinx-markdown-builder`extension for markdown generation
- Update copyright year and version number in sphinx config 
