### PR TITLE
[SNC-16 CAT-827] add: expose id cursor for submission list

### DIFF
--- a/indico/client/request.py
+++ b/indico/client/request.py
@@ -77,8 +77,11 @@ class PagedRequest(GraphQLRequest):
     def process_response(self, response):
         response = super().process_response(response)
         _pg = next(iter(response.values()))["pageInfo"]
-        self.has_next_page = _pg["hasNextPage"]
-        self.variables["after"] = _pg["endCursor"] if self.has_next_page else None
+        # if limit isn't set, both of the following are None
+        self.has_next_page = bool(_pg["hasNextPage"])
+        # if limit is greater than the aggregate count, the
+        # endCursor is just the aggregate count
+        self.variables["after"] = _pg["endCursor"]
         return response
 
 

--- a/indico/client/request.py
+++ b/indico/client/request.py
@@ -69,7 +69,8 @@ class PagedRequest(GraphQLRequest):
     """
 
     def __init__(self, query: str, variables: Dict[str, Any] = None):
-        variables["after"] = None
+        if "after" not in variables:
+            variables["after"] = None
         self.has_next_page = True
         super().__init__(query, variables=variables)
 

--- a/indico/queries/submission.py
+++ b/indico/queries/submission.py
@@ -2,7 +2,7 @@ import json
 import time
 from functools import partial
 from operator import eq, ne
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 
 from indico.client.request import GraphQLRequest, RequestChain, PagedRequest
 from indico.errors import IndicoInputError, IndicoTimeoutError
@@ -24,6 +24,7 @@ class ListSubmissions(PagedRequest):
         limit (int, default=1000): Maximum number of Submissions to return
         orderBy (str, default="ID"): Submission attribute to filter by
         desc: (bool, default=True): List in descending order
+        after: (int): Submission id after which to start paginating; when unsupplied, pagination starts from the first Submission.
 
     Returns:
         List[Submission]: All the found Submission objects
@@ -39,7 +40,6 @@ class ListSubmissions(PagedRequest):
             $orderBy: SUBMISSION_COLUMN_ENUM,
             $desc: Boolean,
             $after: Int
-
         ){
             submissions(
                 submissionIds: $submissionIds,
@@ -49,7 +49,6 @@ class ListSubmissions(PagedRequest):
                 orderBy: $orderBy,
                 desc: $desc,
                 after: $after
-
             ){
                 submissions {
                     id
@@ -83,12 +82,13 @@ class ListSubmissions(PagedRequest):
     def __init__(
         self,
         *,
-        submission_ids: List[int] = None,
-        workflow_ids: List[int] = None,
-        filters: Union[Dict, SubmissionFilter] = None,
+        submission_ids: Optional[List[int]] = None,
+        workflow_ids: Optional[List[int]] = None,
+        filters: Optional[Union[Dict, SubmissionFilter]] = None,
         limit: int = 1000,
         order_by: str = "ID",
         desc: bool = True,
+        after: Optional[int] = None,
     ):
         super().__init__(
             self.query,
@@ -99,6 +99,7 @@ class ListSubmissions(PagedRequest):
                 "limit": limit,
                 "orderBy": order_by,
                 "desc": desc,
+                "after": after,
             },
         )
 
@@ -437,7 +438,7 @@ class RetrySubmission(GraphQLRequest):
         submission_ids (List[int]): the given submission ids to retry.
     Options:
 
-    Raises: 
+    Raises:
         IndicoInputError
 
     """

--- a/indico/queries/submission.py
+++ b/indico/queries/submission.py
@@ -24,7 +24,7 @@ class ListSubmissions(PagedRequest):
         limit (int, default=1000): Maximum number of Submissions to return
         orderBy (str, default="ID"): Submission attribute to filter by
         desc: (bool, default=True): List in descending order
-        after: (int): Submission id after which to start paginating; when unsupplied, pagination starts from the first Submission.
+        after: (int): The index of a Submission in the aggregated filtered list after which to start paginating; when unsupplied, pagination starts from the first Submission.
 
     Returns:
         List[Submission]: All the found Submission objects


### PR DESCRIPTION
## Summary

Expose the submission id cursor to pagination requests, allow for initial supplying of the cursor, and ensure the cursor is available to read back out again after any page is queried.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] Jira story/task is put into PR title
- [x] Code has been self-reviewed
- [ ] Hard-to-understand areas have been commented
- [x] Documentation has been updated
- [ ] My changes generate no new warnings
- [ ] Unit tests have been added for base functionality and known edge cases
- [ ] Any dependent changes have been merged and published in downstream modules
