### PR TITLE
[DEV-11456] make request chains wait appropriately for sync/async calls

### DIFF
--- a/examples/aio_client.py
+++ b/examples/aio_client.py
@@ -47,4 +47,4 @@ async def example_1(client):
 
 if __name__ == "__main__":
     # How to run a Python script using async
-    asyncio.run(example_with_client)
+    asyncio.run(example_with_client())

--- a/indico/client/client.py
+++ b/indico/client/client.py
@@ -42,7 +42,6 @@ class IndicoClient:
     def _handle_request_chain(self, chain: RequestChain):
         response = None
         for request in chain.requests():
-            print(request)
             if isinstance(request, HTTPRequest):
                 response = self._http.execute_request(request)
                 chain.previous = response
@@ -144,7 +143,6 @@ class AsyncIndicoClient:
     async def _handle_request_chain(self, chain: RequestChain):
         response = None
         for request in chain.requests():
-            print(request)
             if isinstance(request, HTTPRequest):
                 response = await self._http.execute_request(request)
                 chain.previous = response

--- a/indico/client/client.py
+++ b/indico/client/client.py
@@ -2,7 +2,8 @@
 
 from typing import Union, Optional
 import urllib3
-
+import time
+import asyncio
 from indico.config import IndicoConfig
 from indico.errors import IndicoError
 from indico.http.client import HTTPClient, AIOHTTPClient
@@ -41,13 +42,15 @@ class IndicoClient:
     def _handle_request_chain(self, chain: RequestChain):
         response = None
         for request in chain.requests():
+            print(request)
             if isinstance(request, HTTPRequest):
                 response = self._http.execute_request(request)
                 chain.previous = response
             elif isinstance(request, RequestChain):
                 response = self._handle_request_chain(request)
                 chain.previous = response
-
+            elif isinstance(request, (float, int)):
+                time.sleep(request)
         if chain.result:
             return chain.result
         return response
@@ -141,13 +144,15 @@ class AsyncIndicoClient:
     async def _handle_request_chain(self, chain: RequestChain):
         response = None
         for request in chain.requests():
+            print(request)
             if isinstance(request, HTTPRequest):
                 response = await self._http.execute_request(request)
                 chain.previous = response
             elif isinstance(request, RequestChain):
                 response = await self._handle_request_chain(request)
                 chain.previous = response
-
+            elif isinstance(request, (float, int)):
+                asyncio.sleep(request)
         if chain.result:
             return chain.result
         return response

--- a/indico/client/client.py
+++ b/indico/client/client.py
@@ -14,7 +14,7 @@ from indico.client.request import (
 )
 from indico.config import IndicoConfig
 from indico.errors import IndicoError
-from indico.client.request import Debouncer
+from indico.client.request import Delay
 from indico.http.client import AIOHTTPClient, HTTPClient
 
 
@@ -51,8 +51,8 @@ class IndicoClient:
             elif isinstance(request, RequestChain):
                 response = self._handle_request_chain(request)
                 chain.previous = response
-            elif isinstance(request, Debouncer):
-                time.sleep(request.backoff())
+            elif isinstance(request, Delay):
+                time.sleep(request.seconds)
         if chain.result:
             return chain.result
         return response
@@ -152,8 +152,8 @@ class AsyncIndicoClient:
             elif isinstance(request, RequestChain):
                 response = await self._handle_request_chain(request)
                 chain.previous = response
-            elif isinstance(request, Debouncer):
-                await asyncio.sleep(request.backoff())
+            elif isinstance(request, Delay):
+                await asyncio.sleep(request.seconds)
         if chain.result:
             return chain.result
         return response

--- a/indico/client/client.py
+++ b/indico/client/client.py
@@ -14,6 +14,7 @@ from indico.client.request import (
 )
 from indico.config import IndicoConfig
 from indico.errors import IndicoError
+from indico.client.request import Debouncer
 from indico.http.client import AIOHTTPClient, HTTPClient
 
 
@@ -50,8 +51,8 @@ class IndicoClient:
             elif isinstance(request, RequestChain):
                 response = self._handle_request_chain(request)
                 chain.previous = response
-            elif isinstance(request, (float, int)):
-                time.sleep(request)
+            elif isinstance(request, Debouncer):
+                time.sleep(request.backoff())
         if chain.result:
             return chain.result
         return response
@@ -151,8 +152,8 @@ class AsyncIndicoClient:
             elif isinstance(request, RequestChain):
                 response = await self._handle_request_chain(request)
                 chain.previous = response
-            elif isinstance(request, (float, int)):
-                asyncio.sleep(request)
+            elif isinstance(request, Debouncer):
+                await asyncio.sleep(request.backoff())
         if chain.result:
             return chain.result
         return response

--- a/indico/client/client.py
+++ b/indico/client/client.py
@@ -1,18 +1,20 @@
 # -*- coding: utf-8 -*-
 
-from typing import Union, Optional
-import urllib3
-import time
 import asyncio
+import time
+from typing import Optional, Union
+
+import urllib3
+
+from indico.client.request import (
+    GraphQLRequest,
+    HTTPRequest,
+    PagedRequest,
+    RequestChain,
+)
 from indico.config import IndicoConfig
 from indico.errors import IndicoError
-from indico.http.client import HTTPClient, AIOHTTPClient
-from indico.client.request import (
-    HTTPRequest,
-    RequestChain,
-    PagedRequest,
-    GraphQLRequest,
-)
+from indico.http.client import AIOHTTPClient, HTTPClient
 
 
 class IndicoClient:

--- a/indico/client/request.py
+++ b/indico/client/request.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Union
 
 from indico.errors import IndicoRequestError
 
@@ -90,11 +90,11 @@ class RequestChain:
 
 
 class Debouncer:
-    def __init__(self, max_timeout: Tuple[int, float] = 5):
+    def __init__(self, max_timeout: Union[int, float] = 5):
         self.timeout = 0
         self.max_timeout = max_timeout or 5  # prevent None and 0
 
-    def backoff(self) -> Tuple[int, float]:
+    def backoff(self) -> Union[int, float]:
         self.increment_timeout()
         return self.timeout
 

--- a/indico/client/request.py
+++ b/indico/client/request.py
@@ -1,7 +1,7 @@
-from typing import Dict, Any
 from enum import Enum
+from typing import Any, Dict, Tuple
+
 from indico.errors import IndicoRequestError
-import time
 
 
 class HTTPMethod(Enum):
@@ -90,11 +90,11 @@ class RequestChain:
 
 
 class Debouncer:
-    def __init__(self, max_timeout: int = 5):
+    def __init__(self, max_timeout: Tuple[int, float] = 5):
         self.timeout = 0
         self.max_timeout = max_timeout or 5  # prevent None and 0
 
-    def backoff(self) -> int:
+    def backoff(self) -> Tuple[int, float]:
         self.increment_timeout()
         return self.timeout
 

--- a/indico/client/request.py
+++ b/indico/client/request.py
@@ -94,9 +94,9 @@ class Debouncer:
         self.timeout = 0
         self.max_timeout = max_timeout or 5  # prevent None and 0
 
-    def backoff(self):
+    def backoff(self) -> int:
         self.increment_timeout()
-        time.sleep(self.timeout)
+        return self.timeout
 
     def increment_timeout(self):
         if self.timeout < self.max_timeout:

--- a/indico/client/request.py
+++ b/indico/client/request.py
@@ -89,15 +89,6 @@ class RequestChain:
         pass
 
 
-class Debouncer:
-    def __init__(self, max_timeout: Union[int, float] = 5):
-        self.timeout = 0
-        self.max_timeout = max_timeout or 5  # prevent None and 0
-
-    def backoff(self) -> Union[int, float]:
-        self.increment_timeout()
-        return self.timeout
-
-    def increment_timeout(self):
-        if self.timeout < self.max_timeout:
-            self.timeout += 1
+class Delay:
+    def __init__(self, seconds: Union[int, float] = 2):
+        self.seconds = seconds

--- a/indico/queries/datasets.py
+++ b/indico/queries/datasets.py
@@ -196,12 +196,17 @@ class CreateDataset(RequestChain):
     Create a dataset and upload the associated files.
 
     Args:
-        name (str): Name of the dataset
-        files (List[str]): List of pathnames to the dataset files
-
-    Options:
-        dataset_type (str): Type of dataset to create [TEXT, DOCUMENT, IMAGE]
-        wait (bool, default=True): Wait for the dataset to upload and finish
+        name (str): Name of the dataset.
+        files (List[str]): List of path names to the dataset files.
+        wait (bool, optional): Wait for the dataset to upload and finish. Defaults to True.
+        dataset_type (str, optional): Type of dataset to create [TEXT, DOCUMENT, IMAGE]. Defaults to TEXT.
+        from_local_images (bool, optional): Flag whether files are local images or not. Defaults to False.
+        image_filename_col (str, optional): Image filename column. Defaults to 'filename'.
+        batch_size (int, optional): Size of file batch to upload at a time. Defaults to 20.
+        ocr_engine (OcrEngine, optional): Specify an OCR engine [OMNIPAGE, READAPI, READAPI_V2, READAPI_TABLES_V1]. Defaults to None.
+        omnipage_ocr_options (OmnipageOcrOptionsInput, optional): If using Omnipage, specify Omnipage OCR options. Defaults to None.
+        read_api_ocr_options: (ReadApiOcrOptionsInput, optional): If using ReadAPI, specify ReadAPI OCR options. Defaults to None.
+        max_wait_time (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5.
 
     Returns:
         Dataset object
@@ -215,7 +220,6 @@ class CreateDataset(RequestChain):
         name: str,
         files: List[str],
         wait: bool = True,
-        max_wait_time: Tuple[int, float] = 5,
         dataset_type: str = "TEXT",
         from_local_images: bool = False,
         image_filename_col: str = "filename",
@@ -223,11 +227,11 @@ class CreateDataset(RequestChain):
         ocr_engine: OcrEngine = None,
         omnipage_ocr_options: OmnipageOcrOptionsInput = None,
         read_api_ocr_options: ReadApiOcrOptionsInput = None,
+        max_wait_time: Union[int, float] = 5,
     ):
         self.files = files
         self.name = name
         self.wait = wait
-        self.max_wait_time = max_wait_time
         self.dataset_type = dataset_type
         self.from_local_images = from_local_images
         self.image_filename_col = image_filename_col
@@ -235,6 +239,7 @@ class CreateDataset(RequestChain):
         self.ocr_engine = ocr_engine
         self.omnipage_ocr_options = omnipage_ocr_options
         self.read_api_ocr_options = read_api_ocr_options
+        self.max_wait_time = max_wait_time
         if omnipage_ocr_options is not None and read_api_ocr_options is not None:
             raise IndicoInputError(
                 "Must supply either omnipage or readapi options but not both."
@@ -539,9 +544,10 @@ class ProcessFiles(RequestChain):
     Process files associated with a dataset and add corresponding data to the dataset
 
     Args:
-        dataset_id (int): ID of the dataset
-        datafile_ids (List[str]): IDs of the datafiles to process
-        wait (bool): Block while polling for status of files
+        dataset_id (int): ID of the dataset.
+        datafile_ids (List[str]): IDs of the datafiles to process.
+        wait (bool, optional): Block while polling for status of files. Defaults to True.
+        max_wait_time (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5.
 
 
     Returns:
@@ -553,7 +559,7 @@ class ProcessFiles(RequestChain):
         dataset_id: int,
         datafile_ids: List[int],
         wait: bool = True,
-        max_wait_time: Tuple[int, float] = 5
+        max_wait_time: Union[int, float] = 5
     ):
         self.dataset_id = dataset_id
         self.datafile_ids = datafile_ids

--- a/indico/queries/datasets.py
+++ b/indico/queries/datasets.py
@@ -3,7 +3,7 @@
 import json
 import tempfile
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Union
 
 import deprecation
 import jsons

--- a/indico/queries/datasets.py
+++ b/indico/queries/datasets.py
@@ -206,7 +206,7 @@ class CreateDataset(RequestChain):
         ocr_engine (OcrEngine, optional): Specify an OCR engine [OMNIPAGE, READAPI, READAPI_V2, READAPI_TABLES_V1]. Defaults to None.
         omnipage_ocr_options (OmnipageOcrOptionsInput, optional): If using Omnipage, specify Omnipage OCR options. Defaults to None.
         read_api_ocr_options: (ReadApiOcrOptionsInput, optional): If using ReadAPI, specify ReadAPI OCR options. Defaults to None.
-        request_interval (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5.
+        request_interval (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5 seconds.
 
     Returns:
         Dataset object
@@ -547,7 +547,7 @@ class ProcessFiles(RequestChain):
         dataset_id (int): ID of the dataset.
         datafile_ids (List[str]): IDs of the datafiles to process.
         wait (bool, optional): Block while polling for status of files. Defaults to True.
-        request_interval (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5.
+        request_interval (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5 seconds.
 
 
     Returns:
@@ -559,7 +559,7 @@ class ProcessFiles(RequestChain):
         dataset_id: int,
         datafile_ids: List[int],
         wait: bool = True,
-        request_interval: Union[int, float] = 5
+        request_interval: Union[int, float] = 5,
     ):
         self.dataset_id = dataset_id
         self.datafile_ids = datafile_ids

--- a/indico/queries/datasets.py
+++ b/indico/queries/datasets.py
@@ -284,7 +284,7 @@ class CreateDataset(RequestChain):
                 [f.status in ["PROCESSED", "FAILED"] for f in self.previous.files]
             ):
                 yield GetDatasetFileStatus(id=dataset_id)
-                debouncer.backoff()
+                yield debouncer.backoff()
         yield GetDataset(id=dataset_id)
 
 
@@ -566,7 +566,7 @@ class ProcessFiles(RequestChain):
                 f.status in ["PROCESSED", "FAILED"] for f in self.previous.files
             ):
                 yield GetDatasetFileStatus(id=self.dataset_id)
-                debouncer.backoff()
+                yield debouncer.backoff()
 
 
 @deprecation.deprecated(

--- a/indico/queries/export.py
+++ b/indico/queries/export.py
@@ -4,7 +4,7 @@ from typing import List, Union
 
 import pandas as pd
 
-from indico.client import Debouncer, GraphQLRequest, RequestChain
+from indico.client import Delay, GraphQLRequest, RequestChain
 from indico.errors import IndicoNotFound, IndicoRequestError
 from indico.queries.storage import RetrieveStorageObject
 from indico.types.export import Export, LabelResolutionStrategy
@@ -233,6 +233,6 @@ class CreateExport(RequestChain):
         if self.wait is True:
             while self.previous.status not in ["COMPLETE", "FAILED"]:
                 yield GetExport(self.previous.id)
-                yield Debouncer(max_timeout=self.request_interval)
+                yield Delay(seconds=self.request_interval)
 
         yield GetExport(self.previous.id)

--- a/indico/queries/export.py
+++ b/indico/queries/export.py
@@ -13,7 +13,7 @@ class _CreateExport(GraphQLRequest):
         mutation CreateExport(
             $datasetId: Int!,
             $labelsetId: Int!,
-            $columnIds: [Int], 
+            $columnIds: [Int],
             $modelIds: [Int],
             $frozenLabelsetIds: [Int],
             $combineLabels: LabelResolutionStrategy,
@@ -93,7 +93,7 @@ class GetExport(GraphQLRequest):
                 exports {
                 id
                 datasetId
-                name 
+                name
                 status
                 columnIds
                 labelsetId
@@ -220,6 +220,6 @@ class CreateExport(RequestChain):
         if self.wait is True:
             while self.previous.status not in ["COMPLETE", "FAILED"]:
                 yield GetExport(self.previous.id)
-                debouncer.backoff()
+                yield debouncer.backoff()
 
         yield GetExport(self.previous.id)

--- a/indico/queries/export.py
+++ b/indico/queries/export.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import io
-from typing import List, Tuple
+from typing import List, Union
 
 from indico.client import GraphQLRequest, RequestChain, Debouncer
 from indico.errors import IndicoNotFound, IndicoRequestError
@@ -165,15 +165,16 @@ class CreateExport(RequestChain):
     Create an export job for a dataset.
 
     Args:
-        dataset_id (int): Dataset to create the export for
-        labelset_id (int): Labelset column id to export
-        column_ids (List(int)): Data column ids to export
-        model_ids (List(int)): Model ids to include predictions from
-        frozen_labelset_ids: (List(int)): frozen labelset ids to limit examples by
-        combine_labels (LabelResolutionStrategy): One row per example, combine labels from multiple labels into a single row
-        file_info (bool): Include datafile information
-        anonymous (bool): Anonymize user information
-        wait (bool): Wait for the export to complete. Default is True
+        dataset_id (int): Dataset to create the export for.
+        labelset_id (int): Labelset column id to export.
+        column_ids (List(int), optional): Data column ids to export. Defaults to None.
+        model_ids (List(int), optional): Model ids to include predictions from. Defaults to None.
+        frozen_labelset_ids: (List(int), optional): frozen labelset ids to limit examples by. Defaults to None.
+        combine_labels (LabelResolutionStrategy, optional): One row per example, combine labels from multiple labels into a single row. Defaults to 'all'.
+        file_info (bool, optional): Include datafile information. Defaults to False.
+        anonymous (bool, optional): Anonymize user information. Defaults to False.
+        wait (bool, optional): Wait for the export to complete. Defaults to True.
+        max_wait_time (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5.
 
     Returns:
         Export object
@@ -193,7 +194,7 @@ class CreateExport(RequestChain):
         file_info: bool = False,
         anonymous: bool = False,
         wait: bool = True,
-        max_wait_time: Tuple[int, float] = 5
+        max_wait_time: Union[int, float] = 5
     ):
         self.dataset_id = dataset_id
         self.labelset_id = labelset_id

--- a/indico/queries/export.py
+++ b/indico/queries/export.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import io
 from typing import List, Union
+import warnings
 
 from indico.client import GraphQLRequest, RequestChain, Debouncer
 from indico.errors import IndicoNotFound, IndicoRequestError
@@ -54,8 +55,15 @@ class _CreateExport(GraphQLRequest):
         frozen_labelset_ids: List[int] = None,
         combine_labels: LabelResolutionStrategy = LabelResolutionStrategy.ALL.name,
         file_info: bool = None,
+        anonymoous: bool = None,
         anonymous: bool = None,
     ):
+        if anonymoous:
+            warnings.warn("Argument anonymoous is deprecated and will be removed in future versions. Use argument anonymous instead.")
+            if anonymous:
+                raise IndicoRequestError("Cannot use both anonymoous and anonymous.")
+            else:
+                anonymous = anonymoous
         super().__init__(
             self.query,
             variables={

--- a/indico/queries/export.py
+++ b/indico/queries/export.py
@@ -185,7 +185,7 @@ class CreateExport(RequestChain):
         file_info (bool, optional): Include datafile information. Defaults to False.
         anonymous (bool, optional): Anonymize user information. Defaults to False.
         wait (bool, optional): Wait for the export to complete. Defaults to True.
-        request_interval (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5.
+        request_interval (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5 seconds.
 
     Returns:
         Export object

--- a/indico/queries/jobs.py
+++ b/indico/queries/jobs.py
@@ -55,7 +55,7 @@ class JobStatus(RequestChain):
         wait (bool, optional): Whether to wait for the job to complete. Defaults to True.
         timeout (float or int, optional): Timeout after this many seconds.
             Ignored if not `wait`. Defaults to None.
-        max_wait_time (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5.
+        request_interval (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 0.2.
 
     Returns:
         Job: With the job result available in a result attribute. Note that the result
@@ -73,10 +73,12 @@ class JobStatus(RequestChain):
         self,
         id: str,
         wait: bool = True,
+        request_interval: Union[int, float] = 0.2,
         timeout: Union[int, float] = None,
     ):
         self.id = id
         self.wait = wait
+        self.request_interval = request_interval
         self.timeout = timeout
 
     def requests(self):
@@ -99,6 +101,6 @@ class JobStatus(RequestChain):
             ):
                 if timer:
                     timer.check()
-                yield Debouncer(max_timeout=self.timeout)
+                yield Debouncer(max_timeout=self.request_interval)
                 yield _JobStatus(id=self.id)
             yield _JobStatusWithResult(id=self.id)

--- a/indico/queries/jobs.py
+++ b/indico/queries/jobs.py
@@ -53,9 +53,9 @@ class JobStatus(RequestChain):
     Args:
         id (int): ID of the job to query for status.
         wait (bool, optional): Whether to wait for the job to complete. Defaults to True.
+        request_interval (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 0.2.
         timeout (float or int, optional): Timeout after this many seconds.
             Ignored if not `wait`. Defaults to None.
-        request_interval (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 0.2.
 
     Returns:
         Job: With the job result available in a result attribute. Note that the result

--- a/indico/queries/jobs.py
+++ b/indico/queries/jobs.py
@@ -91,6 +91,6 @@ class JobStatus(RequestChain):
                 if self.timeout is not None:
                     timer = Timer(self.timeout)
                     timer.check()
-                time.sleep(self.request_interval)
+                yield self.request_interval
                 yield _JobStatus(id=self.id)
             yield _JobStatusWithResult(id=self.id)

--- a/indico/queries/jobs.py
+++ b/indico/queries/jobs.py
@@ -52,7 +52,7 @@ class JobStatus(RequestChain):
 
     Args:
         id (int): ID of the job to query for status.
-        wait (bool, optional): Whether to ait for the job to complete. Default is True
+        wait (bool, optional): Whether to wait for the job to complete. Defaults to True.
         timeout (float or int, optional): Timeout after this many seconds.
             Ignored if not `wait`. Defaults to None.
         max_wait_time (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5.
@@ -82,6 +82,7 @@ class JobStatus(RequestChain):
     def requests(self):
         yield _JobStatus(id=self.id)
         if self.wait:
+            timer = None
             if self.timeout is not None:
                 timer = Timer(self.timeout)
             # Check status of job until done if wait == True
@@ -96,7 +97,7 @@ class JobStatus(RequestChain):
                     "RETRY",
                 ]
             ):
-                if self.timeout is not None:
+                if timer:
                     timer.check()
                 yield Debouncer(max_timeout=self.timeout)
                 yield _JobStatus(id=self.id)

--- a/indico/queries/jobs.py
+++ b/indico/queries/jobs.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from typing import Union
 
-from indico.client.request import Debouncer, GraphQLRequest, RequestChain
+from indico.client.request import Delay, GraphQLRequest, RequestChain
 from indico.types.jobs import Job
 from indico.types.utils import Timer
 
@@ -101,6 +101,6 @@ class JobStatus(RequestChain):
             ):
                 if timer:
                     timer.check()
-                yield Debouncer(max_timeout=self.request_interval)
+                yield Delay(seconds=self.request_interval)
                 yield _JobStatus(id=self.id)
             yield _JobStatusWithResult(id=self.id)

--- a/indico/queries/model_groups/model_groups.py
+++ b/indico/queries/model_groups/model_groups.py
@@ -19,7 +19,7 @@ class GetModelGroup(RequestChain):
     Args:
         id (int): model group id to query
         wait (bool, optional): Wait until the Model Group status is FAILED, COMPLETE, or NOT_ENOUGH_DATA. Defaults to False.
-        request_interval (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5.
+        request_interval (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5 seconds.
 
     Returns:
         ModelGroup object

--- a/indico/queries/model_groups/model_groups.py
+++ b/indico/queries/model_groups/model_groups.py
@@ -36,7 +36,7 @@ class GetModelGroup(RequestChain):
             req = GetModelGroupSelectedModelStatus(id=self.id)
             yield req
             while self.previous not in ["FAILED", "COMPLETE", "NOT_ENOUGH_DATA"]:
-                sleep(1)
+                yield 1
                 yield req
         yield _GetModelGroup(id=self.id)
 
@@ -226,7 +226,7 @@ class CreateModelGroup(RequestChain):
             req = GetModelGroupSelectedModelStatus(id=model_group_id)
             yield req
             while self.previous not in ["FAILED", "COMPLETE", "NOT_ENOUGH_DATA"]:
-                sleep(1)
+                yield 1
                 yield req
 
         yield _GetModelGroup(id=model_group_id)

--- a/indico/queries/model_groups/model_groups.py
+++ b/indico/queries/model_groups/model_groups.py
@@ -19,25 +19,25 @@ class GetModelGroup(RequestChain):
     Args:
         id (int): model group id to query
         wait (bool, optional): Wait until the Model Group status is FAILED, COMPLETE, or NOT_ENOUGH_DATA. Defaults to False.
-        max_wait_time (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5.
+        request_interval (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5.
 
     Returns:
         ModelGroup object
     """
 
     def __init__(
-        self, id: int, wait: bool = False, max_wait_time: Union[int, float] = 5
+        self, id: int, wait: bool = False, request_interval: Union[int, float] = 5
     ):
         self.id = id
         self.wait = wait
-        self.max_wait_time = max_wait_time
+        self.request_interval = request_interval
 
     def requests(self):
         if self.wait:
             req = GetModelGroupSelectedModelStatus(id=self.id)
             yield req
             while self.previous not in ["FAILED", "COMPLETE", "NOT_ENOUGH_DATA"]:
-                yield Debouncer(max_timeout=self.max_wait_time)
+                yield Debouncer(max_timeout=self.request_interval)
                 yield req
         yield _GetModelGroup(id=self.id)
 
@@ -197,7 +197,7 @@ class CreateModelGroup(RequestChain):
         wait: bool = False,
         model_training_options: dict = None,
         model_type: str = None,
-        max_wait_time: Union[int, float] = 5,
+        request_interval: Union[int, float] = 5,
     ):
         self.name = name
         self.dataset_id = dataset_id
@@ -208,7 +208,7 @@ class CreateModelGroup(RequestChain):
         self.model_type = model_type
         self.workflow_id = workflow_id
         self.after_component_id = after_component_id
-        self.max_wait_time = max_wait_time
+        self.request_interval = request_interval
 
     def requests(self):
         yield AddModelGroupComponent(
@@ -228,7 +228,7 @@ class CreateModelGroup(RequestChain):
             req = GetModelGroupSelectedModelStatus(id=model_group_id)
             yield req
             while self.previous not in ["FAILED", "COMPLETE", "NOT_ENOUGH_DATA"]:
-                yield Debouncer(max_timeout=self.max_wait_time)
+                yield Debouncer(max_timeout=self.request_interval)
                 yield req
 
         yield _GetModelGroup(id=model_group_id)

--- a/indico/queries/model_groups/model_groups.py
+++ b/indico/queries/model_groups/model_groups.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Union
 
 import deprecation
 
-from indico.client.request import Debouncer, GraphQLRequest, RequestChain
+from indico.client.request import Delay, GraphQLRequest, RequestChain
 from indico.errors import IndicoNotFound
 from indico.queries.workflow_components import AddModelGroupComponent
 from indico.types.jobs import Job
@@ -37,7 +37,7 @@ class GetModelGroup(RequestChain):
             req = GetModelGroupSelectedModelStatus(id=self.id)
             yield req
             while self.previous not in ["FAILED", "COMPLETE", "NOT_ENOUGH_DATA"]:
-                yield Debouncer(max_timeout=self.request_interval)
+                yield Delay(seconds=self.request_interval)
                 yield req
         yield _GetModelGroup(id=self.id)
 
@@ -228,7 +228,7 @@ class CreateModelGroup(RequestChain):
             req = GetModelGroupSelectedModelStatus(id=model_group_id)
             yield req
             while self.previous not in ["FAILED", "COMPLETE", "NOT_ENOUGH_DATA"]:
-                yield Debouncer(max_timeout=self.request_interval)
+                yield Delay(seconds=self.request_interval)
                 yield req
 
         yield _GetModelGroup(id=model_group_id)

--- a/indico/queries/model_groups/model_groups.py
+++ b/indico/queries/model_groups/model_groups.py
@@ -1,19 +1,15 @@
 import json
-from time import sleep
-from typing import List, Dict
+from typing import Dict, List, Tuple
 
 import deprecation
 
-from indico.client.request import GraphQLRequest, RequestChain
+from indico.client.request import Debouncer, GraphQLRequest, RequestChain
+from indico.errors import IndicoNotFound
 from indico.queries.workflow_components import AddModelGroupComponent
-from indico.types import Workflow
-from indico.types.model_group import ModelGroup, NewLabelsetArguments, \
-    NewQuestionnaireArguments
-from indico.types.model import Model
 from indico.types.jobs import Job
+from indico.types.model import Model
+from indico.types.model_group import ModelGroup
 from indico.types.utils import cc_to_snake
-
-from indico.errors import IndicoNotFound, IndicoError, IndicoInputError
 
 
 class GetModelGroup(RequestChain):
@@ -27,16 +23,19 @@ class GetModelGroup(RequestChain):
         ModelGroup object
     """
 
-    def __init__(self, id: int, wait: bool = False):
+    def __init__(
+        self, id: int, wait: bool = False, max_wait_time: Tuple[int, float] = 5
+    ):
         self.id = id
         self.wait = wait
+        self.max_wait_time = max_wait_time
 
     def requests(self):
         if self.wait:
             req = GetModelGroupSelectedModelStatus(id=self.id)
             yield req
             while self.previous not in ["FAILED", "COMPLETE", "NOT_ENOUGH_DATA"]:
-                yield 1
+                yield Debouncer(max_timeout=self.max_wait_time)
                 yield req
         yield _GetModelGroup(id=self.id)
 
@@ -128,7 +127,6 @@ class GetTrainingModelWithProgress(GraphQLRequest):
         return Model(**last)
 
 
-
 class GetModelGroupSelectedModelStatus(GraphQLRequest):
     """
     Get the status string of the selected model for the given model group id
@@ -164,8 +162,9 @@ class GetModelGroupSelectedModelStatus(GraphQLRequest):
         return mg.selected_model.status
 
 
-@deprecation.deprecated(deprecated_in="5.0",
-                        details="Use AddModelGroupComponent instead")
+@deprecation.deprecated(
+    deprecated_in="5.0", details="Use AddModelGroupComponent instead"
+)
 class CreateModelGroup(RequestChain):
     """
     Create a new model group and train a model
@@ -186,16 +185,17 @@ class CreateModelGroup(RequestChain):
     """
 
     def __init__(
-            self,
-            name: str,
-            dataset_id: int,
-            source_column_id: int,
-            labelset_id: int,
-            workflow_id: int,
-            after_component_id: int,
-            wait: bool = False,
-            model_training_options: dict = None,
-            model_type: str = None
+        self,
+        name: str,
+        dataset_id: int,
+        source_column_id: int,
+        labelset_id: int,
+        workflow_id: int,
+        after_component_id: int,
+        wait: bool = False,
+        model_training_options: dict = None,
+        model_type: str = None,
+        max_wait_time: Tuple[int, float] = 5,
     ):
         self.name = name
         self.dataset_id = dataset_id
@@ -206,6 +206,7 @@ class CreateModelGroup(RequestChain):
         self.model_type = model_type
         self.workflow_id = workflow_id
         self.after_component_id = after_component_id
+        self.max_wait_time = max_wait_time
 
     def requests(self):
         yield AddModelGroupComponent(
@@ -216,8 +217,7 @@ class CreateModelGroup(RequestChain):
             model_training_options=self.model_training_options,
             model_type=self.model_type,
             workflow_id=self.workflow_id,
-            after_component_id=self.after_component_id
-
+            after_component_id=self.after_component_id,
         )
 
         mg = self.previous.model_group_by_name(self.name)
@@ -226,13 +226,15 @@ class CreateModelGroup(RequestChain):
             req = GetModelGroupSelectedModelStatus(id=model_group_id)
             yield req
             while self.previous not in ["FAILED", "COMPLETE", "NOT_ENOUGH_DATA"]:
-                yield 1
+                yield Debouncer(max_timeout=self.max_wait_time)
                 yield req
 
         yield _GetModelGroup(id=model_group_id)
 
-@deprecation.deprecated(deprecated_in="6.0",
-                        details="Removed from platform. This call is a no-op.")
+
+@deprecation.deprecated(
+    deprecated_in="6.0", details="Removed from platform. This call is a no-op."
+)
 class LoadModel(GraphQLRequest):
     """
     Load model into system cache (implicit in ModelGroupPredict unless load=False)
@@ -318,11 +320,11 @@ class ModelGroupPredict(RequestChain):
     """
 
     def __init__(
-            self,
-            model_id: int,
-            data: List[str],
-            load: bool = True,
-            predict_options: Dict = None,
+        self,
+        model_id: int,
+        data: List[str],
+        load: bool = True,
+        predict_options: Dict = None,
     ):
         self.model_id = model_id
         self.data = data
@@ -333,4 +335,3 @@ class ModelGroupPredict(RequestChain):
         yield _ModelGroupPredict(
             model_id=self.model_id, data=self.data, predict_options=self.predict_options
         )
-

--- a/indico/queries/model_groups/model_groups.py
+++ b/indico/queries/model_groups/model_groups.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List, Tuple
+from typing import Dict, List, Union
 
 import deprecation
 
@@ -18,13 +18,15 @@ class GetModelGroup(RequestChain):
 
     Args:
         id (int): model group id to query
+        wait (bool, optional): Wait until the Model Group status is FAILED, COMPLETE, or NOT_ENOUGH_DATA. Defaults to False.
+        max_wait_time (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5.
 
     Returns:
         ModelGroup object
     """
 
     def __init__(
-        self, id: int, wait: bool = False, max_wait_time: Tuple[int, float] = 5
+        self, id: int, wait: bool = False, max_wait_time: Union[int, float] = 5
     ):
         self.id = id
         self.wait = wait
@@ -195,7 +197,7 @@ class CreateModelGroup(RequestChain):
         wait: bool = False,
         model_training_options: dict = None,
         model_type: str = None,
-        max_wait_time: Tuple[int, float] = 5,
+        max_wait_time: Union[int, float] = 5,
     ):
         self.name = name
         self.dataset_id = dataset_id

--- a/indico/queries/questionnaire.py
+++ b/indico/queries/questionnaire.py
@@ -7,7 +7,7 @@ from indico.queries.datasets import CreateDataset, GetDataset
 from indico.client.request import (
     GraphQLRequest,
     RequestChain,
-    Debouncer,
+    Delay,
 )
 from indico.queries import AddModelGroupComponent
 from indico.types import NewLabelsetArguments, NewQuestionnaireArguments, Workflow, ModelTaskType
@@ -322,9 +322,8 @@ class CreateQuestionaire(RequestChain):
         ).model_group.questionnaire_id
         yield GetQuestionnaire(questionaire_id)
         status = self.previous.questions_status
-        debouncer = Debouncer()
         while status == "STARTED":
-            debouncer.backoff()
+            yield Delay()
             yield GetQuestionnaire(questionaire_id)
             status = self.previous.questions_status
 

--- a/indico/queries/submission.py
+++ b/indico/queries/submission.py
@@ -1,7 +1,7 @@
 import json
 from functools import partial
 from operator import eq, ne
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Union
 
 from indico.client.request import Debouncer, GraphQLRequest, PagedRequest, RequestChain
 from indico.errors import IndicoInputError, IndicoTimeoutError
@@ -378,7 +378,7 @@ class SubmissionResult(RequestChain):
         check_status: str = None,
         wait: bool = False,
         timeout: Union[int, float] = 30,
-        max_wait_time: Tuple[int, float] = 5,
+        max_wait_time: Union[int, float] = 5,
     ):
         self.submission_id = (
             submission if isinstance(submission, int) else submission.id

--- a/indico/queries/submission.py
+++ b/indico/queries/submission.py
@@ -403,7 +403,7 @@ class SubmissionResult(RequestChain):
             while not self.status_check(self.previous.status):
                 timer.check()
                 yield GetSubmission(self.submission_id)
-                time.sleep(1)
+                yield 1
             if not self.status_check(self.previous.status):
                 raise IndicoTimeoutError(timer.elapsed)
         elif not self.status_check(self.previous.status):

--- a/indico/queries/submission.py
+++ b/indico/queries/submission.py
@@ -3,7 +3,7 @@ from functools import partial
 from operator import eq, ne
 from typing import Dict, List, Union
 
-from indico.client.request import Debouncer, GraphQLRequest, PagedRequest, RequestChain
+from indico.client.request import Delay, GraphQLRequest, PagedRequest, RequestChain
 from indico.errors import IndicoInputError, IndicoTimeoutError
 from indico.filters import SubmissionFilter
 from indico.queries import JobStatus
@@ -405,7 +405,7 @@ class SubmissionResult(RequestChain):
             while not self.status_check(self.previous.status):
                 timer.check()
                 yield GetSubmission(self.submission_id)
-                yield Debouncer(max_timeout=self.request_interval)
+                yield Delay(seconds=self.request_interval)
             if not self.status_check(self.previous.status):
                 raise IndicoTimeoutError(timer.elapsed)
         elif not self.status_check(self.previous.status):

--- a/indico/queries/submission.py
+++ b/indico/queries/submission.py
@@ -357,7 +357,7 @@ class SubmissionResult(RequestChain):
             and wait for the result file to be generated. Defaults to False
         timeout (int or float, optional): Maximum number of seconds to wait before
             timing out. Ignored if not `wait`. Defaults to 30
-        request_interval (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5.
+        request_interval (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5 seconds.
 
     Returns:
         Job: A Job that can be watched for results

--- a/indico/queries/submission.py
+++ b/indico/queries/submission.py
@@ -357,6 +357,7 @@ class SubmissionResult(RequestChain):
             and wait for the result file to be generated. Defaults to False
         timeout (int or float, optional): Maximum number of seconds to wait before
             timing out. Ignored if not `wait`. Defaults to 30
+        max_wait_time (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5.
 
     Returns:
         Job: A Job that can be watched for results

--- a/indico/queries/submission.py
+++ b/indico/queries/submission.py
@@ -357,7 +357,7 @@ class SubmissionResult(RequestChain):
             and wait for the result file to be generated. Defaults to False
         timeout (int or float, optional): Maximum number of seconds to wait before
             timing out. Ignored if not `wait`. Defaults to 30
-        max_wait_time (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5.
+        request_interval (int or float, optional): The maximum time in between retry calls when waiting. Defaults to 5.
 
     Returns:
         Job: A Job that can be watched for results
@@ -378,14 +378,14 @@ class SubmissionResult(RequestChain):
         check_status: str = None,
         wait: bool = False,
         timeout: Union[int, float] = 30,
-        max_wait_time: Union[int, float] = 5,
+        request_interval: Union[int, float] = 5,
     ):
         self.submission_id = (
             submission if isinstance(submission, int) else submission.id
         )
         self.wait = wait
         self.timeout = timeout
-        self.max_wait_time = max_wait_time
+        self.request_interval = request_interval
         if check_status and check_status.upper() not in VALID_SUBMISSION_STATUSES:
             raise IndicoInputError(
                 f"{check_status} is not one of valid submission statuses: "
@@ -405,7 +405,7 @@ class SubmissionResult(RequestChain):
             while not self.status_check(self.previous.status):
                 timer.check()
                 yield GetSubmission(self.submission_id)
-                yield Debouncer(max_timeout=self.max_wait_time)
+                yield Debouncer(max_timeout=self.request_interval)
             if not self.status_check(self.previous.status):
                 raise IndicoTimeoutError(timer.elapsed)
         elif not self.status_check(self.previous.status):

--- a/indico/queries/workflow.py
+++ b/indico/queries/workflow.py
@@ -3,7 +3,7 @@ import json
 import tempfile
 from typing import Dict, List, Union
 
-from indico.client.request import Debouncer, GraphQLRequest, RequestChain
+from indico.client.request import Delay, GraphQLRequest, RequestChain
 from indico.errors import IndicoError, IndicoInputError
 from indico.queries.storage import UploadBatched, UploadDocument
 from indico.types import SUBMISSION_RESULT_VERSIONS, Job, Submission, Workflow
@@ -486,11 +486,9 @@ class AddDataToWorkflow(RequestChain):
         yield _AddDataToWorkflow(self.workflow_id)
 
         if self.wait:
-            debouncer = Debouncer()
-
             while self.previous.status != "COMPLETE":
                 yield GetWorkflow(workflow_id=self.workflow_id)
-                debouncer.backoff()
+                yield Delay()
 
 
 class CreateWorkflow(GraphQLRequest):


### PR DESCRIPTION
## Summary
Request chains with a wait argument use time.sleep() internally, rather than yielding a delay to the client to sleep synchronously or asynchronously as appropriate. Moved sleeping to client and making all wait calls yield a float or integer denoting sleep time

## Type of change
<!--
Please delete options that are not relevant.
-->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--
A quick checklist of things that should be done before the code is opened to review by others on the team.
Delete any that are not applicable.
-->

- [x] Jira story/task is put into PR title
- [x] Code has been self-reviewed
- [x] Hard-to-understand areas have been commented
- [x] Documentation has been updated
- [x] My changes generate no new warnings
- [x] Unit tests have been added for base functionality and known edge cases
- [x] Any dependent changes have been merged and published in downstream modules
