### PR TITLE
[DEV-11651] Reduce base install size by making Msgpack, Numpy, and Pandas optional dependencies

### DIFF
--- a/indico/http/serialization.py
+++ b/indico/http/serialization.py
@@ -70,6 +70,14 @@ def raw_bytes(content, *args, **kwargs):
 
 
 def msgpack_deserialization(content, charset):
+    try:
+        import msgpack
+    except ImportError as error:
+        raise RuntimeError(
+            "msgpack deserialization requires additional dependencies: "
+            "`pip install indico-client[deserialization]`"
+        ) from error
+
     return msgpack.unpackb(content)
 
 

--- a/indico/queries/datasets.py
+++ b/indico/queries/datasets.py
@@ -7,7 +7,6 @@ from typing import Dict, List, Optional, Union
 
 import deprecation
 import jsons
-import pandas as pd
 
 from indico.client.request import (
     Delay,
@@ -249,6 +248,15 @@ class CreateDataset(RequestChain):
     def requests(self):
         if self.from_local_images:
             self.dataset_type = "IMAGE"
+
+            try:
+                import pandas as pd
+            except ImportError as error:
+                raise RuntimeError(
+                    "creating image datasets requires additional dependencies:"
+                    "`pip install indico-client[datasets]`"
+                ) from error
+
             # Assume image filenames are in the same directory as the csv with
             # image labels and that there is a column representing their name
             df = pd.read_csv(self.files)

--- a/indico/queries/export.py
+++ b/indico/queries/export.py
@@ -2,8 +2,6 @@ import io
 import warnings
 from typing import List, Union
 
-import pandas as pd
-
 from indico.client import Delay, GraphQLRequest, RequestChain
 from indico.errors import IndicoNotFound, IndicoRequestError
 from indico.queries.storage import RetrieveStorageObject
@@ -129,6 +127,14 @@ class GetExport(GraphQLRequest):
 
 class _RetrieveExport(RetrieveStorageObject):
     def process_response(self, response):
+        try:
+            import pandas as pd
+        except ImportError as error:
+            raise RuntimeError(
+                "downloading exports requires additional dependencies: "
+                "`pip install indico-client[exports]`"
+            ) from error
+
         response = super().process_response(response)
         return pd.read_csv(io.StringIO(response))
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,12 @@ setup(
         "aiohttp[speedups]"
     ],
     extras_require={
+        "all": [
+            "msgpack>=0.5.6",
+            "msgpack-numpy==0.4.4.3",
+            "numpy>=1.16.0",
+            "pandas>=1.0.3",
+        ],
         "datasets": [
             "pandas>=1.0.3",
         ],

--- a/setup.py
+++ b/setup.py
@@ -20,17 +20,22 @@ setup(
     install_requires=[
         "requests>=2.22.0",
         "setuptools>=41.4.0",
-        "pandas>=1.0.3",
         'importlib-metadata ~= 1.0 ; python_version < "3.8"',
         "deprecation>=2.1.0",
         "jsons",
         "aiohttp[speedups]"
     ],
     extras_require={
+        "datasets": [
+            "pandas>=1.0.3",
+        ],
         "deserialization": [
             "msgpack>=0.5.6",
             "msgpack-numpy==0.4.4.3",
             "numpy>=1.16.0",
+        ],
+        "exports": [
+            "pandas>=1.0.3",
         ],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,6 @@ setup(
     author_email="engineering@indico.io",
     tests_require=["pytest>=5.2.1", "requests-mock>=1.8.0", "pytest-asyncio"],
     install_requires=[
-        "msgpack>=0.5.6",
-        "msgpack-numpy==0.4.4.3",
-        "numpy>=1.16.0",
         "requests>=2.22.0",
         "setuptools>=41.4.0",
         "pandas>=1.0.3",
@@ -29,4 +26,11 @@ setup(
         "jsons",
         "aiohttp[speedups]"
     ],
+    extras_require={
+        "deserialization": [
+            "msgpack>=0.5.6",
+            "msgpack-numpy==0.4.4.3",
+            "numpy>=1.16.0",
+        ],
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
         "msgpack>=0.5.6",
         "msgpack-numpy==0.4.4.3",
         "numpy>=1.16.0",
-        "Pillow>=6.2.0",
         "requests>=2.22.0",
         "setuptools>=41.4.0",
         "pandas>=1.0.3",

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 envlist = py38,py39,py310,py311,py312
 
 [testenv]
+extras = all
 parallel_show_output = true
 # install pytest in the virtualenv where commands will be executed
 deps =


### PR DESCRIPTION
## Summary

Make large dependencies like Numpy and Pandas optional to reduce the base install size of the client. These are required by only a handful of uncommon calls, yet represent 75% of the install size. This will better support customers who use the client in AWS Lambdas where they're limited to 250Mb.

```
[michael@macbook indico-client-python]$ du -hd 1 . | grep venv
 37M    ./venv-base
146M    ./venv-all
```

## Changelog

- Removed `pillow` as it appears to be unneeded.
- Made `msgpack` and `numpy` optional as they are only used for specific deserialization functions.
  - Available via the `indico-client[deserialization]` or `indico-client[all]` extras.
- Made `pandas` optional as it is only used for creating image datasets and retrieving exports.
  - Available via the `indico-client[datasets]`, `indico-client[exports]`, or `indico-client[all]` extras.
  - Pandas could be dropped entirely if `CreateDataset` manipulated CSVs with the native `csv` module and `DownloadExport` returned a CSV string instead of a dataframe.
- Added instructional errors when functionality is used that requires optional dependencies that are not installed.


## Type of change
<!--
Please delete options that are not relevant.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:
<!--
A quick checklist of things that should be done before the code is opened to review by others on the team.
Delete any that are not applicable.
-->

- [x] Jira story/task is put into PR title
- [x] Code has been self-reviewed
- [ ] Hard-to-understand areas have been commented
- [ ] Documentation has been updated
- [x] My changes generate no new warnings
- [ ] Unit tests have been added for base functionality and known edge cases
- [ ] Any dependent changes have been merged and published in downstream modules
