### PR TITLE
[DEV-11730]: fix async client handle files

### DIFF
--- a/indico/http/client.py
+++ b/indico/http/client.py
@@ -1,21 +1,23 @@
 import asyncio
-import aiohttp
 import http.cookiejar
 import logging
 from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
-from typing import Union, Optional
+from typing import Optional, Union
 
+import aiohttp
 import requests
+
 from indico.client.request import HTTPRequest
 from indico.config import IndicoConfig
 from indico.errors import (
     IndicoAuthenticationFailed,
-    IndicoRequestError,
     IndicoHibernationError,
+    IndicoRequestError,
 )
-from indico.http.serialization import deserialize, aio_deserialize
+from indico.http.serialization import aio_deserialize, deserialize
+
 from .retry import aioretry
 
 logger = logging.getLogger(__file__)
@@ -87,7 +89,6 @@ class HTTPClient:
 
     @contextmanager
     def _handle_files(self, req_kwargs):
-
         streams = None
         # deepcopying buffers is not supported
         # so, remove "streams" before the deepcopy.
@@ -256,7 +257,7 @@ class AIOHTTPClient(HTTPClient):
                 )
                 dup_counts[path.stem] += 1
             else:
-                data.add_field("file", fd, filename=path.stem)
+                data.add_field("file", fd, filename=path.name)
                 dup_counts[path.stem] = 1
             file_args.append(data)
 
@@ -313,7 +314,6 @@ class AIOHTTPClient(HTTPClient):
                 verify_ssl=self.config.verify_ssl,
                 **request_kwargs,
             ) as response:
-
                 # If auth expired refresh
                 if response.status == 401 and not _refreshed:
                     await self.get_short_lived_access_token()

--- a/tests/unit/client/test_aiohttp_client.py
+++ b/tests/unit/client/test_aiohttp_client.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from indico.client import AIOHTTPClient
+from indico.config import IndicoConfig
+
+
+@pytest.fixture
+async def aiohttp_client():
+    config = IndicoConfig(protocol="https", host="example.com", api_token="dummy_token")
+    client = AIOHTTPClient(config=config)
+    yield client
+    await client.request_session.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_files_correct_filename(aiohttp_client):
+    file_path = Path("/tmp/testfile.txt")
+
+    request_kwargs = {"files": [file_path]}
+
+    with patch("pathlib.Path.open", new_callable=MagicMock) as mock_open:
+        mock_open.return_value = MagicMock()
+        with aiohttp_client._handle_files(request_kwargs) as file_args:
+            assert len(file_args) == 1
+            for arg in file_args:
+                fields = arg._fields
+                for field in fields:
+                    field_dict = field[0]
+                    filename = field_dict.get("filename")
+                    assert filename == "testfile.txt"
+    await aiohttp_client.request_session.close()


### PR DESCRIPTION
AsyncIndicoClient _handle_files context manager incorrectly updated the file args for the aiohttp call. Instead of using the path.name for the file to upload we used path.stem, resulting in the file extension being lost

streams correctly captured the filename, as well as the sync _handles_file manager