### PR TITLE
change: replace custom typing with Pydantic 2

### DIFF
--- a/indico/http/serialization.py
+++ b/indico/http/serialization.py
@@ -2,14 +2,14 @@
 Handles deserialization / decoding of responses
 """
 
-import cgi
 import gzip
 import io
 import json
 import logging
 import traceback
 from collections import defaultdict
-from typing import TYPE_CHECKING
+from email.message import Message
+from typing import TYPE_CHECKING, Dict, Tuple
 
 import msgpack
 
@@ -24,6 +24,14 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = logging.getLogger(__name__)
 
 
+def _parse_header(header: str) -> Tuple[str, Dict[str, str]]:
+    """Parse a header and return as a tuple of a main value and additional params"""
+    m = Message()
+    m["content-type"] = header
+    params = m.get_params(failobj=[])
+    return params[0][0], dict(params[1:])
+
+
 def decompress(response: "Response") -> bytes:
     response.raw.decode_content = True
     value: bytes = io.BytesIO(response.raw.data).getvalue()
@@ -33,7 +41,7 @@ def decompress(response: "Response") -> bytes:
 def deserialize(
     response: "Response", force_json: bool = False, force_decompress: bool = False
 ) -> "Any":
-    content_type, params = cgi.parse_header(response.headers["Content-Type"])
+    content_type, params = _parse_header(response.headers["Content-Type"])
     content: bytes
 
     if force_decompress or content_type in ["application/x-gzip", "application/gzip"]:
@@ -59,7 +67,7 @@ def deserialize(
 async def aio_deserialize(
     response: "ClientResponse", force_json: bool = False, force_decompress: bool = False
 ) -> "Any":
-    content_type, params = cgi.parse_header(response.headers["Content-Type"])
+    content_type, params = _parse_header(response.headers["Content-Type"])
     content: bytes = await response.read()
 
     if force_decompress or content_type in ["application/x-gzip", "application/gzip"]:

--- a/indico/queries/forms.py
+++ b/indico/queries/forms.py
@@ -4,7 +4,7 @@ from indico.client.request import GraphQLRequest, RequestChain
 from indico.queries.storage import UploadBatched, UploadDocument
 from indico.types import Job
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Iterator, List, Optional, Union
 
     from indico.typing import AnyDict, Payload

--- a/indico/types/base.py
+++ b/indico/types/base.py
@@ -1,90 +1,20 @@
-import inspect
 import json
-from datetime import datetime
-from typing import TYPE_CHECKING, Any, List, cast, get_origin
+from typing import Any
 
-from indico.types.utils import cc_to_snake
-
-if TYPE_CHECKING:  # pragma: no cover
-    from typing import Iterable, Optional
-
-    from indico.typing import AnyDict
-
-generic_alias_cls = type(List[Any])
+from pydantic import AliasGenerator, BaseModel, BeforeValidator, ConfigDict
+from pydantic.alias_generators import to_camel
+from typing_extensions import Annotated
 
 
-def list_subtype(cls: "Any") -> "Optional[Any]":
-    if not issubclass(type(cls), generic_alias_cls):
-        return None
-
-    origin: "Optional[type]" = getattr(
-        cls, "__origin__", getattr(cls, "__extra__", None)
-    )
-    if (
-        origin is not None
-        and type(origin) == type
-        and issubclass(origin, list)
-        and cls.__args__
-    ):
-        return cls.__args__[0]
-
-    return None
-
-
-def valid_type(v: "Any") -> bool:
-    if v is None:
-        return False
-
-    return (
-        (inspect.isclass(v) and issubclass(v, BaseType))
-        or v in [str, int, float, bool, JSONType, datetime]
-        or get_origin(v) is dict
-        or valid_type(list_subtype(v))
+class BaseType(BaseModel):
+    model_config = ConfigDict(
+        # alias fields so that they can be provided using their GraphQL
+        # field names (camel case) or by their python names (snake case)
+        alias_generator=AliasGenerator(validation_alias=to_camel),
+        populate_by_name=True,
     )
 
 
-# TODO: all the introspection here class makes the typing sus
-class BaseType:
-    def _get_attrs(self) -> "AnyDict":
-        classes = inspect.getmro(self.__class__)
-        props: "AnyDict" = dict()
-
-        for c in classes:
-            if not getattr(c, "__annotations__", None):
-                continue
-            props.update({k: v for k, v in c.__annotations__.items() if valid_type(v)})
-
-        return props
-
-    def __init__(self, **kwargs: "Any"):
-        attrs: "AnyDict" = self._get_attrs()
-
-        for k, v in kwargs.items():
-            k = cc_to_snake(k)
-            if k in attrs:
-                attr_type = attrs[k]
-                if (
-                    v is not None
-                    and inspect.isclass(attr_type)
-                    and issubclass(attr_type, BaseType)
-                ):
-                    v = attrs[k](**v)
-
-                if attr_type == JSONType and v is not None:
-                    v = json.loads(v)
-
-                if attr_type == datetime and v is not None:
-                    try:
-                        v = datetime.fromtimestamp(float(v))
-                    except ValueError:
-                        v = datetime.fromisoformat(v)
-
-                subtype = list_subtype(attr_type)
-                if subtype and issubclass(subtype, BaseType):
-                    v = [subtype(**x) for x in cast("Iterable[Any]", v)]
-
-                setattr(self, k, v)
-
-
-class JSONType:
-    pass
+# this really should be dict[str, Any], but that breaks static typing since we supply
+# the field as a string but the model's type would be annotated as a dict
+JSONType = Annotated[Any, BeforeValidator(json.loads)]

--- a/indico/types/base.py
+++ b/indico/types/base.py
@@ -22,6 +22,11 @@ class BaseType(BaseModel):
         # field names (camel case) or by their python names (snake case)
         alias_generator=AliasGenerator(validation_alias=to_camel),
         populate_by_name=True,
+        # by default, pydantic warns if a model defines a field prefixed with 'model_'.
+        # we have a lot of those, so we can omit that namespace from the warnings.
+        # pydantic will still throw an error if we define a field that clashes with an
+        # built-in internal one, though.
+        protected_namespaces=(),
     )
 
     @field_validator("*", mode="before")

--- a/indico/types/jobs.py
+++ b/indico/types/jobs.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from typing import TYPE_CHECKING
+
+from typing import Optional
+
+from pydantic import Field
 
 from indico.types.base import BaseType, JSONType
-
-if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any
 
 
 class Job(BaseType):
@@ -22,13 +22,7 @@ class Job(BaseType):
         ready (bool):
     """
 
-    id: int
-    status: str
-    result: JSONType
-    ready: bool
-
-    def __init__(self, **kwargs: "Any"):
-        if "jobId" in kwargs:
-            kwargs["id"] = kwargs["jobId"]
-            del kwargs["jobId"]
-        super().__init__(**kwargs)
+    id: int = Field(validation_alias="jobId")
+    status: Optional[str] = None
+    result: Optional[JSONType] = None
+    ready: Optional[bool] = None

--- a/indico/types/utils.py
+++ b/indico/types/utils.py
@@ -2,17 +2,18 @@ import re
 import time
 from typing import TYPE_CHECKING
 
+from pydantic.alias_generators import to_snake
+
 from indico.errors import IndicoTimeoutError
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Match, NoReturn, Optional, Union
 
-_cc_to_snake_re = re.compile(r"(?<!^)(?=[A-Z])")
 _snake_to_cc_re = re.compile(r"(.*?)_([a-zA-Z])")
 
 
 def cc_to_snake(string: str) -> str:
-    return re.sub(_cc_to_snake_re, "_", string).lower()
+    return to_snake(string)
 
 
 def _camel(match: "Match[str]") -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,4 @@ profile = "black"
 strict = true
 packages = ["indico"]
 mypy_path = "./stubs:${MYPYPATH}"
+plugins = ["pydantic.mypy"]

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,6 @@ setup(
         "deprecation>=2.1.0",
         "jsons",
         "aiohttp[speedups]",
+        "pydantic>=2",
     ],
 )


### PR DESCRIPTION
## Summary

Replacing all the custom type parsing stuff with Pydantic 2.

Based on my existing static typing branch.

Pydantic parses a few things slightly differently than we were, namely datetimes, so I've patched that validation to ensure backwards compat:
```bash
$ docker compose run --rm tester
  py38: OK (13.09=setup[8.93]+cmd[3.34,0.82] seconds)
  py39: OK (12.42=setup[7.22]+cmd[4.04,1.15] seconds)
  py310: OK (12.78=setup[8.52]+cmd[3.37,0.89] seconds)
  py311: OK (11.81=setup[7.50]+cmd[3.23,1.07] seconds)
  py312: OK (11.88=setup[7.30]+cmd[3.57,1.01] seconds)
  congratulations :) (13.15 seconds)
```

Also fix some deprecations.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
