### PR TITLE
[DEV-12949] Python 3.13 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ---
 
-Required: Python 3.6, 3.7, or 3.8
+Required: Python 3.9+
 
 From PyPI:
 

--- a/indico/http/serialization.py
+++ b/indico/http/serialization.py
@@ -1,13 +1,13 @@
 """
 Handles deserialization / decoding of responses
 """
-import cgi
 import gzip
 import io
 import json
 import logging
 import traceback
 from collections import defaultdict
+from email.message import EmailMessage
 
 from indico.errors import IndicoDecodingError
 
@@ -21,7 +21,7 @@ def decompress(response):
 
 
 def deserialize(response, force_json=False, force_decompress=False):
-    content_type, params = cgi.parse_header(response.headers.get("Content-Type"))
+    content_type, params = parse_header(response.headers.get("Content-Type"))
 
     if force_decompress or content_type in ["application/x-gzip", "application/gzip"]:
         content = decompress(response)
@@ -43,7 +43,7 @@ def deserialize(response, force_json=False, force_decompress=False):
         )
 
 async def aio_deserialize(response, force_json=False, force_decompress=False):
-    content_type, params = cgi.parse_header(response.headers.get("Content-Type"))
+    content_type, params = parse_header(response.headers.get("Content-Type"))
     content = await response.read()
 
     if force_decompress or content_type in ["application/x-gzip", "application/gzip"]:
@@ -62,6 +62,11 @@ async def aio_deserialize(response, force_json=False, force_decompress=False):
         raise IndicoDecodingError(
             content_type, charset, content.decode("ascii", "ignore")
         )
+
+def parse_header(header: str) -> tuple[str, dict[str, str]]:
+    email = EmailMessage()
+    email["Content-Type"] = header
+    return email.get_content_type(), email["Content-Type"].params
 
 def raw_bytes(content, *args, **kwargs):
     return content

--- a/indico/http/serialization.py
+++ b/indico/http/serialization.py
@@ -9,8 +9,6 @@ import logging
 import traceback
 from collections import defaultdict
 
-import msgpack
-
 from indico.errors import IndicoDecodingError
 
 logger = logging.getLogger(__name__)

--- a/tox.Dockerfile
+++ b/tox.Dockerfile
@@ -6,7 +6,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yqq apt-tr
 #deadsnakes holds old versions of python for ubuntu
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -yqq software-properties-common && add-apt-repository ppa:deadsnakes/ppa
 
-RUN  DEBIAN_FRONTEND=noninteractive apt-get -yqq install  python3.7 python3.8 python3.9 python3.10 python3.11 python3.12 python3-pip
+RUN  DEBIAN_FRONTEND=noninteractive apt-get -yqq install python3.9 python3.10 python3.11 python3.12 python3.13 python3-pip
 
 RUN pip3 install tox==4.11.3
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py38,py39,py310,py311,py312
+envlist = py39,py310,py311,py312,py313
 
 [testenv]
 extras = all


### PR DESCRIPTION
## Summary

Python 3.13 removed the deprecated `cgi` module. This PR replaces usage of `cgi.parse_header()` with `email.message.EmailMessage` per the [release notes](https://docs.python.org/3/whatsnew/3.13.html#pep-594-remove-dead-batteries-from-the-standard-library) to make it 3.13-compatible.

(Also removes the unconditional import of `msgpack` which I missed in #314 🙃)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
<!--
A quick checklist of things that should be done before the code is opened to review by others on the team.
Delete any that are not applicable.
-->

- [x] Jira story/task is put into PR title
- [x] Code has been self-reviewed
- [ ] Hard-to-understand areas have been commented
- [x] Documentation has been updated
- [x] My changes generate no new warnings
- [ ] Unit tests have been added for base functionality and known edge cases
- [ ] Any dependent changes have been merged and published in downstream modules
