### PR TITLE
[DEV-14683] Remove extra quotation marks

### DIFF
--- a/indico/client/client.py
+++ b/indico/client/client.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # here to avoid circular imports
 class GetIPAVersion(GraphQLRequest[str]):
     query = """
-        "query getIPAVersion {
+        query getIPAVersion {
             ipaVersion
         }
     """


### PR DESCRIPTION
Client-reported that calling get_ipa_version complained about unterminated quotation marks. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a syntax error in the `GetIPAVersion` GraphQL query string that caused unterminated quotation/parse errors.
> 
> - Removes an extra leading quote in `indico/client/client.py` within `GetIPAVersion.query` so the query parses correctly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 595021b91412a3e5e490ec58d5123acf9c2ae3a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->