### PR TITLE
feat: [DEV-14864] add submission cancellation query support

### DIFF
--- a/indico/queries/submission.py
+++ b/indico/queries/submission.py
@@ -7,7 +7,12 @@ from indico.client.request import Delay, GraphQLRequest, PagedRequest, RequestCh
 from indico.errors import IndicoInputError, IndicoTimeoutError
 from indico.filters import SubmissionFilter
 from indico.queries import JobStatus
-from indico.types import Job, Submission, SubmissionReviewFull
+from indico.types import (
+    Job,
+    Submission,
+    SubmissionCancellationResult,
+    SubmissionReviewFull,
+)
 from indico.types.submission import VALID_SUBMISSION_STATUSES
 from indico.types.utils import Timer
 
@@ -626,3 +631,36 @@ class RetrySubmission(GraphQLRequest["List[Submission]"]):
         return [
             Submission(**s) for s in super().parse_payload(response)["retrySubmissions"]
         ]
+
+
+class CancelSubmissions(GraphQLRequest["SubmissionCancellationResult"]):
+    """
+    Given a list of submission ids, cancel those active submissions.
+
+    Args:
+        submission_ids (List[int]): the given submission ids to cancel.
+    """
+
+    query = """
+    mutation cancelSubmissions($submissionIds:[Int]!){
+      cancelSubmissions(submissionIds: $submissionIds){
+        cancelled
+        skipped{
+          submissionId
+          reason
+        }
+      }
+    }
+    """
+
+    def __init__(self, submission_ids: "List[int]"):
+        if submission_ids is None or len(submission_ids) < 1:
+            raise IndicoInputError("You must specify submission ids")
+        if len(set(submission_ids)) != len(submission_ids):
+            raise IndicoInputError("Cannot include duplicate submission ids")
+
+        super().__init__(self.query, variables={"submissionIds": submission_ids})
+
+    def process_response(self, response: "Payload") -> "SubmissionCancellationResult":
+        payload = super().parse_payload(response)["cancelSubmissions"]
+        return SubmissionCancellationResult(**payload)

--- a/indico/types/submission.py
+++ b/indico/types/submission.py
@@ -42,6 +42,32 @@ class SubmissionRetries(BaseType):
     submission_id: int
 
 
+class SubmissionCancellationSkipped(BaseType):
+    """
+    Information about a submission that was skipped during cancellation.
+
+    Attributes:
+        submission_id (int): The ID of the submission that was not cancelled.
+        reason (str): The reason it was skipped.
+    """
+
+    submission_id: int
+    reason: str
+
+
+class SubmissionCancellationResult(BaseType):
+    """
+    Result payload from a submission cancellation request.
+
+    Attributes:
+        cancelled (List[int]): Submission IDs that were successfully cancelled.
+        skipped (List[SubmissionCancellationSkipped]): Submission IDs that were skipped.
+    """
+
+    cancelled: List[int]
+    skipped: List[SubmissionCancellationSkipped]
+
+
 class SubmissionReview(BaseType):
     f"""
     Information about a submission's Reviews.

--- a/tests/unit/test_submission_cancel.py
+++ b/tests/unit/test_submission_cancel.py
@@ -1,0 +1,35 @@
+import pytest
+
+from indico.errors import IndicoInputError
+from indico.queries import CancelSubmissions
+from indico.types import SubmissionCancellationResult
+
+
+def test_cancel_submissions_requires_ids() -> None:
+    with pytest.raises(IndicoInputError, match="must specify submission ids"):
+        CancelSubmissions([])
+
+
+def test_cancel_submissions_rejects_duplicate_ids() -> None:
+    with pytest.raises(IndicoInputError, match="duplicate submission ids"):
+        CancelSubmissions([1, 1])
+
+
+def test_cancel_submissions_process_response() -> None:
+    request = CancelSubmissions([1, 2])
+    result = request.process_response(
+        {
+            "data": {
+                "cancelSubmissions": {
+                    "cancelled": [1],
+                    "skipped": [{"submissionId": 2, "reason": "already terminal"}],
+                }
+            }
+        }
+    )
+
+    assert isinstance(result, SubmissionCancellationResult)
+    assert result.cancelled == [1]
+    assert len(result.skipped) == 1
+    assert result.skipped[0].submission_id == 2
+    assert result.skipped[0].reason == "already terminal"


### PR DESCRIPTION
## Summary
- Add Python SDK GraphQL support for submission cancellation (`cancelSubmissions`) including typed response models.
- Add unit tests for validation and response parsing.
- Branch is based on latest `master` and contains only DEV-14864 cancellation changes.

## Changelog Summary
- Added `CancelSubmissions` query in `indico/queries/submission.py`.
- Added `SubmissionCancellationResult` and `SubmissionCancellationSkipped` types in `indico/types/submission.py`.
- Added unit tests in `tests/unit/test_submission_cancel.py`.

## Contract Changes
- New client-side GraphQL mutation request class: `CancelSubmissions(submission_ids=[...])`.
- New typed result object containing `cancelled` and `skipped` entries.

## Backward Compatibility / Breaking Changes
- No breaking changes.
- Existing query interfaces are unchanged.

## Tests and Verification Added
- `pytest -q tests/unit/test_submission_cancel.py` (passes).

## Net New Behaviors Requiring Integration Tests
- New cancellation mutation path should be covered in integration tests against a live cluster when available.

## Validation
- Local unit test run for new query/type behavior.

## Confluence Changelog
- [IPA Change Log (7.10.0 section)](https://indicodata.atlassian.net/wiki/spaces/BE/pages/4631625736/IPA+Change+Log)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new query class, response types, and unit tests without changing existing submission query behavior.
> 
> **Overview**
> Adds SDK support for cancelling active submissions via a new `CancelSubmissions` GraphQL mutation, including input validation (non-empty, no duplicates) and typed parsing into `SubmissionCancellationResult` (with per-submission skip reasons).
> 
> Introduces new submission cancellation response models in `indico/types/submission.py` and covers the new behavior with unit tests for validation and response mapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e487fb7b7fde7dee56e2745bf6065bdfad52eca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->