### PR TITLE
DEV-14971: Python SDK storage-service compatibility unit tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,1 +1,2 @@
 Oct 16 2019 v2.0.0: Complete change of IndicoIo API through the Indico IPA platform. For IPA Platform API use only.
+Mar 13 2026 Unreleased: Support matching release tags that include dotted PEP 440 suffixes (for example `7.9.0.post1`) in dynamic versioning.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ source = "uv-dynamic-versioning"
 [tool.uv-dynamic-versioning]
 fallback-version = "0.0.0"
 vcs = "git"
-pattern = "^(?P<base>\\d+(?:\\.\\d+)*)(?:-(?P<stage>[a-zA-Z]+)(?P<revision>\\d+)?)?"
+pattern = "^(?P<base>\\d+(?:\\.\\d+)*)(?:(?:[-\\.])(?P<stage>[a-zA-Z]+)(?P<revision>\\d+)?)?$"
 
 [tool.uv]
 cache-keys = [{ file = "pyproject.toml" }, { git = { commit = true, tags = true } }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,10 @@ module = "importlib_metadata"
 ignore_missing_imports = true
 
 [dependency-groups]
-dev = ["pytest>=8.4.2", "pytest-mock>=3.15.1"]
+dev = [
+    "pytest>=8.4.2",
+    "pytest-asyncio>0.21",
+    "pytest-mock>=3.15.1",
+    "requests-mock>=1.8.0",
+    "msgpack>=0.5.6",
+]

--- a/tests/integration/queries/test_gallery.py
+++ b/tests/integration/queries/test_gallery.py
@@ -77,9 +77,9 @@ def test_list_gallery_pagination(indico):
     if len(blueprints) >= 2:
         # Check that we have unique blueprints
         blueprint_ids = [bp.id for bp in blueprints]
-        assert len(blueprint_ids) == len(
-            set(blueprint_ids)
-        ), "Duplicate blueprints found in pagination"
+        assert len(blueprint_ids) == len(set(blueprint_ids)), (
+            "Duplicate blueprints found in pagination"
+        )
 
 
 def test_get_gallery_tags(indico):

--- a/tests/unit/test_release_version_pattern.py
+++ b/tests/unit/test_release_version_pattern.py
@@ -1,0 +1,31 @@
+import re
+import tomllib
+from pathlib import Path
+
+
+def _load_release_pattern() -> str:
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    with pyproject_path.open("rb") as f:
+        pyproject = tomllib.load(f)
+    return pyproject["tool"]["uv-dynamic-versioning"]["pattern"]
+
+
+def test_release_pattern_matches_standard_tag() -> None:
+    pattern = re.compile(_load_release_pattern())
+    match = pattern.match("7.9.0")
+    assert match is not None
+    assert match.groupdict() == {"base": "7.9.0", "stage": None, "revision": None}
+
+
+def test_release_pattern_matches_hyphen_prerelease_tag() -> None:
+    pattern = re.compile(_load_release_pattern())
+    match = pattern.match("7.9.0-rc1")
+    assert match is not None
+    assert match.groupdict() == {"base": "7.9.0", "stage": "rc", "revision": "1"}
+
+
+def test_release_pattern_matches_post_release_tag() -> None:
+    pattern = re.compile(_load_release_pattern())
+    match = pattern.match("7.9.0.post1")
+    assert match is not None
+    assert match.groupdict() == {"base": "7.9.0", "stage": "post", "revision": "1"}

--- a/tests/unit/test_release_version_pattern.py
+++ b/tests/unit/test_release_version_pattern.py
@@ -1,6 +1,10 @@
 import re
-import tomllib
 from pathlib import Path
+
+try:  # pragma: no cover - exercised indirectly on Python <3.11 tox envs
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
 
 
 def _load_release_pattern() -> str:

--- a/tests/unit/test_storage_compat.py
+++ b/tests/unit/test_storage_compat.py
@@ -1,0 +1,181 @@
+"""
+Storage-service compatibility unit tests.
+
+Validates that Python SDK storage query classes remain compatible with the
+response shapes produced by storage-service (the Rainbow replacement).  These
+tests mock at the HTTP level and require no running service.
+
+Covered flows:
+  * UploadDocument: POST /storage/files/store, LegacyUploadResponseItem shape
+  * CreateStorageURLs: indico-file:///storage<path> URI construction
+  * RetrieveStorageObject: indico-file:// prefix stripping and GET path
+"""
+
+import io
+import json
+
+import pytest
+
+from indico.client import IndicoClient
+from indico.client.request import HTTPMethod
+from indico.config import IndicoConfig
+from indico.queries.storage import (
+    CreateStorageURLs,
+    RetrieveStorageObject,
+    UploadDocument,
+)
+
+# ---------------------------------------------------------------------------
+# Response shape produced by storage-service /files/store endpoint
+# (mirrors LegacyUploadResponseItem from storage_service/routes/blob_routes.py)
+# ---------------------------------------------------------------------------
+STORAGE_SERVICE_UPLOAD_RESPONSE = [
+    {
+        "path": "/uploads/42/abc-uuid",
+        "name": "document.pdf",
+        "size": 12345,
+        "upload_type": "user",
+    }
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cfg():
+    return IndicoConfig(protocol="mock", host="mock")
+
+
+@pytest.fixture
+def mock_request(requests_mock, cfg):
+    """Register a URL on requests_mock using the test config base URL."""
+
+    def _register(method, path, **kwargs):
+        url = f"{cfg.protocol}://{cfg.host}{path}"
+        getattr(requests_mock, method)(
+            url, **kwargs, headers={"Content-Type": "application/json"}
+        )
+
+    return _register
+
+
+@pytest.fixture
+def client(mock_request, cfg):
+    mock_request("post", "/auth/users/refresh_token", json={"auth_token": "tok"})
+    return IndicoClient(config=cfg)
+
+
+# ---------------------------------------------------------------------------
+# UploadDocument — request shape and response parsing
+# ---------------------------------------------------------------------------
+
+
+def test_upload_document_posts_to_storage_files_store(mock_request, client):
+    """UploadDocument sends POST to /storage/files/store."""
+    captured = []
+
+    def capture(request, context):
+        captured.append(request.path)
+        context.status_code = 200
+        context.headers["Content-Type"] = "application/json"
+        import json as _json
+
+        return _json.dumps(STORAGE_SERVICE_UPLOAD_RESPONSE)
+
+    mock_request("post", "/storage/files/store", text=capture)
+    client.call(UploadDocument(streams={"test.pdf": io.BytesIO(b"data")}))
+    assert captured == ["/storage/files/store"]
+
+
+def test_upload_document_processes_path_name_upload_type(mock_request, client):
+    """UploadDocument.process_response reads path/name/upload_type from storage-service."""
+    mock_request("post", "/storage/files/store", json=STORAGE_SERVICE_UPLOAD_RESPONSE)
+    result = client.call(UploadDocument(streams={"test.pdf": io.BytesIO(b"data")}))
+
+    assert len(result) == 1
+    assert result[0]["filename"] == "document.pdf"
+    meta = json.loads(result[0]["filemeta"])
+    assert meta["path"] == "/uploads/42/abc-uuid"
+    assert meta["name"] == "document.pdf"
+    assert meta["uploadType"] == "user"
+
+
+def test_upload_document_handles_multiple_files(mock_request, client):
+    """Multiple files in one upload are each parsed correctly."""
+    multi_response = [
+        {
+            "path": "/uploads/42/uuid-1",
+            "name": "a.pdf",
+            "size": 100,
+            "upload_type": "user",
+        },
+        {
+            "path": "/uploads/42/uuid-2",
+            "name": "b.pdf",
+            "size": 200,
+            "upload_type": "user",
+        },
+    ]
+    mock_request("post", "/storage/files/store", json=multi_response)
+    result = client.call(
+        UploadDocument(
+            streams={
+                "a.pdf": io.BytesIO(b"aaa"),
+                "b.pdf": io.BytesIO(b"bbb"),
+            }
+        )
+    )
+    assert len(result) == 2
+    assert result[0]["filename"] == "a.pdf"
+    assert result[1]["filename"] == "b.pdf"
+
+
+# ---------------------------------------------------------------------------
+# CreateStorageURLs — indico-file URI construction
+# ---------------------------------------------------------------------------
+
+
+def test_create_storage_urls_builds_indico_file_uris(mock_request, client):
+    """CreateStorageURLs returns indico-file:///storage<path> from storage-service response."""
+    mock_request("post", "/storage/files/store", json=STORAGE_SERVICE_UPLOAD_RESPONSE)
+    result = client.call(CreateStorageURLs(streams={"test.pdf": io.BytesIO(b"data")}))
+    assert result == ["indico-file:///storage/uploads/42/abc-uuid"]
+
+
+def test_create_storage_urls_round_trips_through_retrieve(mock_request, client):
+    """A URI from CreateStorageURLs can be fed directly into RetrieveStorageObject."""
+    uri = "indico-file:///storage/uploads/42/abc-uuid"
+    req = RetrieveStorageObject(uri)
+    assert req.path == "/storage/uploads/42/abc-uuid"
+    assert req.method == HTTPMethod.GET
+
+
+# ---------------------------------------------------------------------------
+# RetrieveStorageObject — path construction
+# ---------------------------------------------------------------------------
+
+
+def test_retrieve_storage_object_strips_indico_file_scheme():
+    """indico-file:// prefix is stripped; remaining path becomes the GET path."""
+    req = RetrieveStorageObject("indico-file:///storage/submissions/1/2/result.json")
+    assert req.path == "/storage/submissions/1/2/result.json"
+    assert req.method == HTTPMethod.GET
+
+
+def test_retrieve_storage_object_accepts_dict_with_url_key():
+    """Accepts a dict with 'url' key (as returned by GraphQL result objects)."""
+    req = RetrieveStorageObject({"url": "indico-file:///storage/extractions/99.json"})
+    assert req.path == "/storage/extractions/99.json"
+
+
+def test_retrieve_storage_object_fetches_content(mock_request, client):
+    """GET /storage/<path> is issued and the response body is returned."""
+    payload = {"status": "complete", "results": [{"text": "hello"}]}
+    mock_request("get", "/storage/submissions/1/2/result.json", json=payload)
+    result = client.call(
+        RetrieveStorageObject("indico-file:///storage/submissions/1/2/result.json")
+    )
+    assert result == payload

--- a/tests/unit/test_storage_compat.py
+++ b/tests/unit/test_storage_compat.py
@@ -51,7 +51,7 @@ STORAGE_SERVICE_UPLOAD_RESPONSE = [
 
 @pytest.fixture
 def cfg():
-    return IndicoConfig(protocol="mock", host="mock")
+    return IndicoConfig(protocol="mock", host="mock", api_token="test-token")
 
 
 @pytest.fixture
@@ -150,7 +150,7 @@ def test_create_storage_urls_builds_indico_file_uris(mock_request, client):
     assert result == ["indico-file:///storage/uploads/42/abc-uuid"]
 
 
-def test_create_storage_urls_round_trips_through_retrieve(mock_request, client):
+def test_create_storage_urls_round_trips_through_retrieve():
     """A URI from CreateStorageURLs can be fed directly into RetrieveStorageObject."""
     uri = "indico-file:///storage/uploads/42/abc-uuid"
     req = RetrieveStorageObject(uri)
@@ -234,7 +234,9 @@ def test_retrieve_storage_object_follows_redirects():
         thread.start()
         try:
             host = f"{server.server_address[0]}:{server.server_address[1]}"
-            client = IndicoClient(config=IndicoConfig(protocol="http", host=host))
+            client = IndicoClient(
+                config=IndicoConfig(protocol="http", host=host, api_token="test-token")
+            )
             result = client.call(
                 RetrieveStorageObject(
                     "indico-file:///storage/submissions/1/2/result.json"

--- a/tests/unit/test_storage_compat.py
+++ b/tests/unit/test_storage_compat.py
@@ -235,7 +235,11 @@ def test_retrieve_storage_object_follows_redirects():
         try:
             host = f"{server.server_address[0]}:{server.server_address[1]}"
             client = IndicoClient(config=IndicoConfig(protocol="http", host=host))
-            result = client.call(RetrieveStorageObject("indico-file:///storage/submissions/1/2/result.json"))
+            result = client.call(
+                RetrieveStorageObject(
+                    "indico-file:///storage/submissions/1/2/result.json"
+                )
+            )
             assert result == payload
         finally:
             server.shutdown()

--- a/tests/unit/test_storage_compat.py
+++ b/tests/unit/test_storage_compat.py
@@ -13,12 +13,17 @@ Covered flows:
 
 import io
 import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
 
 import pytest
 
 from indico.client import IndicoClient
 from indico.client.request import HTTPMethod
 from indico.config import IndicoConfig
+from indico.errors import IndicoRequestError
+from indico.queries.model_import import _UploadSMExport
 from indico.queries.storage import (
     CreateStorageURLs,
     RetrieveStorageObject,
@@ -179,3 +184,104 @@ def test_retrieve_storage_object_fetches_content(mock_request, client):
         RetrieveStorageObject("indico-file:///storage/submissions/1/2/result.json")
     )
     assert result == payload
+
+
+def test_retrieve_storage_object_follows_redirects():
+    """Storage GET requests follow redirects in redirect-mode deployments."""
+    payload = {"status": "complete", "results": [{"text": "redirected"}]}
+    refresh_path = "/auth/users/refresh_token"
+    source_path = "/storage/submissions/1/2/result.json"
+    redirected_path = "/storage/signed/submissions/1/2/result.json"
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            if self.path != refresh_path:
+                self.send_response(404)
+                self.end_headers()
+                return
+            body = json.dumps({"auth_token": "tok"}).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):  # noqa: N802
+            if self.path == source_path:
+                self.send_response(302)
+                self.send_header(
+                    "Location",
+                    f"http://{self.server.server_address[0]}:{self.server.server_address[1]}{redirected_path}",
+                )
+                self.end_headers()
+                return
+            if self.path == redirected_path:
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            self.send_response(404)
+            self.end_headers()
+
+        def log_message(self, format, *args):  # noqa: A003
+            return
+
+    with HTTPServer(("127.0.0.1", 0), Handler) as server:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            host = f"{server.server_address[0]}:{server.server_address[1]}"
+            client = IndicoClient(config=IndicoConfig(protocol="http", host=host))
+            result = client.call(RetrieveStorageObject("indico-file:///storage/submissions/1/2/result.json"))
+            assert result == payload
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+
+
+def test_upload_static_model_export_puts_zip_to_signed_url(tmp_path, requests_mock):
+    """Static model export upload uses the signed URL with zip content-type."""
+    export_path = tmp_path / "model.zip"
+    export_bytes = b"zip-bytes"
+    export_path.write_bytes(export_bytes)
+    signed_url = "https://signed.example/upload"
+    storage_uri = "indico-file:///storage/exports/model.zip"
+
+    requests_mock.put(signed_url, status_code=200, text="")
+
+    request = _UploadSMExport(str(export_path))
+    result = request.process_response(
+        {"data": {"exportUpload": {"signedUrl": signed_url, "storageUri": storage_uri}}}
+    )
+
+    assert result == storage_uri
+    assert len(requests_mock.request_history) == 1
+    put_call = requests_mock.request_history[0]
+    assert put_call.method == "PUT"
+    assert put_call.headers["Content-Type"] == "application/zip"
+    assert put_call.body == export_bytes
+
+
+def test_upload_static_model_export_raises_on_put_failure(tmp_path, requests_mock):
+    """A failing signed-url PUT raises IndicoRequestError."""
+    export_path = tmp_path / "model.zip"
+    export_path.write_bytes(b"zip-bytes")
+    signed_url = "https://signed.example/upload"
+
+    requests_mock.put(signed_url, status_code=403, text="forbidden")
+
+    request = _UploadSMExport(str(Path(export_path)))
+    with pytest.raises(IndicoRequestError):
+        request.process_response(
+            {
+                "data": {
+                    "exportUpload": {
+                        "signedUrl": signed_url,
+                        "storageUri": "indico-file:///storage/exports/model.zip",
+                    }
+                }
+            }
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     pytest < 8
     pytest-asyncio > 0.21
     requests-mock >= 1.8.0
+    tomli; python_version < "3.11"
     mypy == 1.8
     typing_extensions
     pandas-stubs

--- a/uv.lock
+++ b/uv.lock
@@ -208,6 +208,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "backports-tarfile"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -415,6 +424,11 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/85/57c314a6b35336efbbdc13e5fc9ae13f6b60a0647cfa7c1221178ac6d8ae/brotlicffi-1.2.0.0.tar.gz", hash = "sha256:34345d8d1f9d534fcac2249e57a4c3c8801a33c9942ff9f8574f67a175e17adb", size = 476682, upload-time = "2025-11-21T18:17:57.334Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/87/ba6298c3d7f8d66ce80d7a487f2a487ebae74a79c6049c7c2990178ce529/brotlicffi-1.2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b13fb476a96f02e477a506423cb5e7bc21e0e3ac4c060c20ba31c44056e38c68", size = 433038, upload-time = "2026-03-05T17:57:37.96Z" },
+    { url = "https://files.pythonhosted.org/packages/00/49/16c7a77d1cae0519953ef0389a11a9c2e2e62e87d04f8e7afbae40124255/brotlicffi-1.2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:17db36fb581f7b951635cd6849553a95c6f2f53c1a707817d06eae5aeff5f6af", size = 1541124, upload-time = "2026-03-05T17:57:39.488Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/17/fab2c36ea820e2288f8c1bf562de1b6cd9f30e28d66f1ce2929a4baff6de/brotlicffi-1.2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40190192790489a7b054312163d0ce82b07d1b6e706251036898ce1684ef12e9", size = 1541983, upload-time = "2026-03-05T17:57:41.061Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c9/849a669b3b3bb8ac96005cdef04df4db658c33443a7fc704a6d4a2f07a56/brotlicffi-1.2.0.0-cp314-cp314t-win32.whl", hash = "sha256:a8079e8ecc32ecef728036a1d9b7105991ce6a5385cf51ee8c02297c90fb08c2", size = 349046, upload-time = "2026-03-05T17:57:42.76Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/25/09c0fd21cfc451fa38ad538f4d18d8be566746531f7f27143f63f8c45a9f/brotlicffi-1.2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:ca90c4266704ca0a94de8f101b4ec029624273380574e4cf19301acfa46c61a0", size = 385653, upload-time = "2026-03-05T17:57:44.224Z" },
     { url = "https://files.pythonhosted.org/packages/e4/df/a72b284d8c7bef0ed5756b41c2eb7d0219a1dd6ac6762f1c7bdbc31ef3af/brotlicffi-1.2.0.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:9458d08a7ccde8e3c0afedbf2c70a8263227a68dea5ab13590593f4c0a4fd5f4", size = 432340, upload-time = "2025-11-21T18:17:42.277Z" },
     { url = "https://files.pythonhosted.org/packages/74/2b/cc55a2d1d6fb4f5d458fba44a3d3f91fb4320aa14145799fd3a996af0686/brotlicffi-1.2.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:84e3d0020cf1bd8b8131f4a07819edee9f283721566fe044a20ec792ca8fd8b7", size = 1534002, upload-time = "2025-11-21T18:17:43.746Z" },
     { url = "https://files.pythonhosted.org/packages/e4/9c/d51486bf366fc7d6735f0e46b5b96ca58dc005b250263525a1eea3cd5d21/brotlicffi-1.2.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:33cfb408d0cff64cd50bef268c0fed397c46fbb53944aa37264148614a62e990", size = 1536547, upload-time = "2025-11-21T18:17:45.729Z" },
@@ -980,9 +994,13 @@ test = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "msgpack" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest-asyncio", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-mock" },
+    { name = "requests-mock" },
 ]
 
 [package.metadata]
@@ -1008,8 +1026,11 @@ provides-extras = ["all", "datasets", "deploy", "deserialization", "exports", "t
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "msgpack", specifier = ">=0.5.6" },
     { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">0.21" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
+    { name = "requests-mock", specifier = ">=1.8.0" },
 ]
 
 [[package]]
@@ -2062,6 +2083,44 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version == '3.10.*'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "pytest-mock"
 version = "3.15.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2131,6 +2190,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "requests-mock"
+version = "1.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/32/587625f91f9a0a3d84688bf9cfc4b2480a7e8ec327cefd0ff2ac891fd2cf/requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401", size = 60901, upload-time = "2024-03-29T03:54:29.446Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/ec/889fbc557727da0c34a33850950310240f2040f3b1955175fdb2b36a8910/requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563", size = 27695, upload-time = "2024-03-29T03:54:27.64Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds unit tests verifying the Python SDK is fully compatible with storage-service response shapes (the Rainbow replacement)
- Audit result: **no client patches needed** — storage-service `/files/store` returns `path`/`name`/`upload_type` matching exactly what `UploadDocument` expects; `indico-file://` URI handling is unchanged
- Tests cover `UploadDocument`, `CreateStorageURLs`, and `RetrieveStorageObject` against the `LegacyUploadResponseItem` response shape

## Test plan

- [x] `test_upload_document_posts_to_storage_files_store` — confirms POST target path
- [x] `test_upload_document_processes_path_name_upload_type` — confirms response field mapping
- [x] `test_upload_document_handles_multiple_files` — multi-file upload batch
- [x] `test_create_storage_urls_builds_indico_file_uris` — URI construction from response
- [x] `test_create_storage_urls_round_trips_through_retrieve` — round-trip URI → path
- [x] `test_retrieve_storage_object_strips_indico_file_scheme` — path extraction
- [x] `test_retrieve_storage_object_accepts_dict_with_url_key` — dict input variant
- [x] `test_retrieve_storage_object_fetches_content` — end-to-end GET with mock response

All 8 tests pass. No network required.

Part of DEV-14699 storage-service migration epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds/adjusts tests and dev tooling dependencies; no production SDK logic changes, so runtime risk is low aside from potential CI/environment dependency issues.
> 
> **Overview**
> Adds new unit coverage to ensure the SDK’s storage queries remain compatible with the storage-service (Rainbow replacement) HTTP response shapes, including `UploadDocument` parsing, `CreateStorageURLs` URI generation, and `RetrieveStorageObject` path handling/redirect behavior, plus signed-URL upload behavior for static model exports.
> 
> Updates test/dev tooling to support these tests (adds `pytest-asyncio`, `requests-mock`, and `tomli` for older Pythons) and refreshes `uv.lock`; also includes a small assertion formatting tweak in the gallery integration test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c54524ac33dc3c56f1f31499699809b41aa2f8b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->